### PR TITLE
Better Error Tracking

### DIFF
--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -35,9 +35,9 @@ compileFile config fileName = do
                 putStrLn "========================================================"
             else pure ()
 
-            if not $ null $ env^.errorMessages then do
+            if not $ null $ env^.errors then do
                 putStrLn "Compilation failed! Errors:"
-                mapM_ print $ env^.errorMessages
+                mapM_ print $ env^.errors
 
             else do
                 if config^.debug > 0 then do

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -35,9 +35,9 @@ compileFile config fileName = do
                 putStrLn "========================================================"
             else pure ()
 
-            if not $ null $ env^.errors then do
+            if not $ null $ env^.errorMessages then do
                 putStrLn "Compilation failed! Errors:"
-                mapM_ print $ env^.errors
+                mapM_ print $ env^.errorMessages
 
             else do
                 if config^.debug > 0 then do

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -16,6 +16,7 @@ data BaseType = Nat | PsaBool | PsaString | Address
               | Record [String] [VarDef]
               | Table [String] Type
               | Named String
+              | Bot
     deriving (Show, Eq)
 
 type VarDef = (String, Type)

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE FlexibleInstances #-}
 
 module AST where
@@ -169,6 +168,7 @@ instance PrettyPrint BaseType where
     prettyPrint (Named t) = [t]
     prettyPrint (Table keys (q,t)) = [ "table(" ++ intercalate ", " keys ++ ") " ++ prettyStr q ++ " " ++ prettyStr t ]
     prettyPrint (Record keys fields) = [ "record(" ++ intercalate ", " keys ++ ") {" ++ intercalate ", " (map prettyStr fields) ++ "}" ]
+    prettyPrint Bot = ["⊥"]
 
 instance PrettyPrint Decl where
     prettyPrint (TypeDecl name ms baseT) =

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances #-}
+
 {-# LANGUAGE FlexibleInstances #-}
 
 module AST where
@@ -172,7 +172,7 @@ instance PrettyPrint BaseType where
 
 instance PrettyPrint Decl where
     prettyPrint (TypeDecl name ms baseT) =
-        [ "type " ++ name ++ " is " ++ intercalate " " (map prettyStr ms) ++ " " ++ prettyStr baseT ]
+        [ "type " ++ name ++ " is " ++ unwords (map prettyStr ms) ++ " " ++ prettyStr baseT ]
     prettyPrint (TransformerDecl name args ret body) =
         [ "transformer " ++ name ++ "(" ++ intercalate ", " (map prettyStr args) ++ ") -> " ++ prettyStr ret ++ "{"]
         ++ concatMap (map indent . prettyPrint) body

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -50,7 +50,7 @@ typeOf x = do
     maybeT <- gets (Map.lookup x . view typeEnv)
     case maybeT of
         Nothing -> do
-            addError $ LookupErrorVar x
+            addError $ LookupError (LookupErrorVar x)
             pure dummyBaseType
         Just t -> pure t
 
@@ -59,10 +59,10 @@ lookupTypeDecl typeName = do
     decl <- gets (Map.lookup typeName . view declarations)
     case decl of
         Nothing -> do
-            addError $ LookupErrorType typeName
+            addError $ LookupError (LookupErrorType typeName)
             pure dummyDecl
         Just tx@TransformerDecl{} -> do
-            addError $ LookupErrorTypeDecl tx
+            addError $ LookupError (LookupErrorTypeDecl tx)
             pure dummyDecl
         Just tdec@TypeDecl{} -> pure tdec
 

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -544,6 +544,7 @@ demoteBaseType (Named t) = do
     decl <- lookupTypeDecl t
     case decl of
         TypeDecl _ _ baseT -> demoteBaseType baseT
+demoteBaseType Bot = pure Bot
 
 typeOfLoc :: Locator -> State Env BaseType
 typeOfLoc (IntConst _) = pure Nat

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -187,7 +187,7 @@ makeConstructor t = do
         TypeDecl _ _ (Record _ _) -> pure $ \args -> SolCall (SolVar t) $ [ SolBool True ] ++ args
         _ -> do
             addError $ TypeError ("Cannot make constructor for: " ++ show decl)
-            pure $ \[arg] -> arg
+            pure $ \_ -> dummySolExpr
 
 makeClosureArgs :: [String] -> State Env [SolVarDecl]
 makeClosureArgs vars = concat <$> mapM go vars

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -293,7 +293,7 @@ lookupValue (Select l k) f = do
                         pure [ If (SolEq valL valK) body ]
 
                     _ -> do
-                        addError $ LookupError ("lookupValue Select is not implemented for: " ++ show kTy)
+                        addError $ UnimplementedError ("lookupValue Select is not implemented for: " ++ show kTy)
                         pure []
 
 lookupValue (Filter l q predName args) f = do
@@ -317,7 +317,7 @@ lookupValue (Filter l q predName args) f = do
         checkCounter Nonempty counter = SolLte (SolInt 1) counter
 
 lookupValue l _ = do
-    addError $ LookupError ("lookupValue is not implemented for: " ++ show l)
+    addError $ UnimplementedError ("lookupValue is not implemented for: " ++ show l)
     pure []
 
 lookupValues :: [Locator] -> ([SolExpr] -> State Env [SolStmt]) -> State Env [SolStmt]
@@ -364,7 +364,7 @@ sendExpr (Named t) e f = f (Named t) e e
 sendExpr (Record keys fields) e f = f (Record keys fields) e e
 
 sendExpr t e f = do
-    addError $ LookupError ("lookupValue Var is not implemented for: " ++ show t)
+    addError $ UnimplementedError ("lookupValue Var is not implemented for: " ++ show t)
     pure []
 
 
@@ -422,7 +422,7 @@ receiveExpr t orig src dst = do
                       [ Delete orig ])
 
             _ -> do
-                addError $ TypeError ("receiveExpr not implemented for: " ++ show demotedT)
+                addError $ FlowError ("receiveExpr not implemented for: " ++ show demotedT)
                 pure ([], [])
 
     if isPrimitiveExpr orig then

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -11,12 +11,12 @@ import qualified Data.Map as Map
 import AST
 import Error
 
-data Env = Env { _freshCounter :: Integer,
-                 _typeEnv      :: Map String BaseType,
-                 _declarations :: Map String Decl,
-                 _solDecls     :: Map String SolDecl,
-                 _allocators   :: Map SolType String,
-                 _errors       :: [Error] }
+data Env = Env { _freshCounter  :: Integer,
+                 _typeEnv       :: Map String BaseType,
+                 _declarations  :: Map String Decl,
+                 _solDecls      :: Map String SolDecl,
+                 _allocators    :: Map SolType String,
+                 _errorMessages :: [String] }
     deriving (Show, Eq)
 makeLenses ''Env
 
@@ -25,12 +25,12 @@ newEnv = Env { _freshCounter = 0,
                _declarations = Map.empty,
                _solDecls = Map.empty,
                _allocators = Map.empty,
-               _errors = [] }
+               _errorMessages = [] }
 
 freshName :: State Env String
 freshName = do
     i <- freshCounter <<+= 1
     pure $ "v" ++ show i
 
-addError :: Error -> State Env ()
-addError e = modify $ over errors (e:)
+addError :: Error e => e -> State Env ()
+addError e = modify $ over errorMessages (prettyStr e:)

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -16,7 +16,7 @@ data Env = Env { _freshCounter  :: Integer,
                  _declarations  :: Map String Decl,
                  _solDecls      :: Map String SolDecl,
                  _allocators    :: Map SolType String,
-                 _errorMessages :: [String] }
+                 _errors :: [Error] }
     deriving (Show, Eq)
 makeLenses ''Env
 
@@ -25,12 +25,12 @@ newEnv = Env { _freshCounter = 0,
                _declarations = Map.empty,
                _solDecls = Map.empty,
                _allocators = Map.empty,
-               _errorMessages = [] }
+               _errors = [] }
 
 freshName :: State Env String
 freshName = do
     i <- freshCounter <<+= 1
     pure $ "v" ++ show i
 
-addError :: Error e => e -> State Env ()
-addError e = modify $ over errorMessages (prettyStr e:)
+addError :: Error -> State Env ()
+addError e = modify $ over errors (e:)

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -2,7 +2,7 @@
 
 module Env where
 
-import Control.Lens (makeLenses, (<<+=))
+import Control.Lens (makeLenses, over, (<<+=))
 import Control.Monad.State
 
 import Data.Map (Map)
@@ -12,11 +12,11 @@ import AST
 import Error
 
 data Env = Env { _freshCounter :: Integer,
-                 _typeEnv :: Map String BaseType,
+                 _typeEnv      :: Map String BaseType,
                  _declarations :: Map String Decl,
-                 _solDecls :: Map String SolDecl,
-                 _allocators :: Map SolType String,
-                 _errors :: [Error] }
+                 _solDecls     :: Map String SolDecl,
+                 _allocators   :: Map SolType String,
+                 _errors       :: [Error] }
     deriving (Show, Eq)
 makeLenses ''Env
 
@@ -32,3 +32,6 @@ freshName = do
     i <- freshCounter <<+= 1
     pure $ "v" ++ show i
 
+addError :: Error -> State Env ()
+addError e = do
+    modify $ over errors (e:)

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -33,5 +33,4 @@ freshName = do
     pure $ "v" ++ show i
 
 addError :: Error -> State Env ()
-addError e = do
-    modify $ over errors (e:)
+addError e = modify $ over errors (e:)

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -12,11 +12,11 @@ newtype FlowError = FlowError String deriving (Eq, Error)
 
 newtype SyntaxError = SyntaxError String deriving (Eq, Error)
 
-newtype UnimplementedError = UnimplementedError String deriving (Eq, Error)
+data UnimplementedError = UnimplementedError String String deriving (Eq, Error)
 
 data TypeError = TypeError String BaseType deriving (Eq, Error)
 
-data LookupError = LookupErrorVar String | LookupErrorTypeUndefined String | LookupErrorTypeInvalid String Decl deriving (Eq, Error)
+data LookupError = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl deriving (Eq, Error)
 
 -- Definitions of prettyPrint for error types
 instance PrettyPrint FlowError where
@@ -26,15 +26,15 @@ instance PrettyPrint SyntaxError where
     prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
 
 instance PrettyPrint UnimplementedError where
-    prettyPrint (UnimplementedError s) = ["UnimplementedError: " ++ s]
+    prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
 
 instance PrettyPrint TypeError where
-     prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " for type " ++ show t]
+    prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
 
 instance PrettyPrint LookupError where
     prettyPrint (LookupErrorVar s) = ["LookupError: Variable " ++ s ++ " is not defined"]
-    prettyPrint (LookupErrorTypeUndefined s) = ["LookupError: Type " ++ s ++ " is not defined"]
-    prettyPrint (LookupErrorTypeInvalid s d) = ["LookupError: Tried to lookup type declaration" ++ s ++ "but got " ++ show d]
+    prettyPrint (LookupErrorType s) = ["LookupError: Type " ++ s ++ " is not defined"]
+    prettyPrint (LookupErrorTypeDecl (TransformerDecl tx _ _ _)) = ["LookupError: expected type but got transformer" ++ show tx]
 
 -- dummy values that are returned as proxies when errors are encountered
 dummyBaseType :: BaseType

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -1,40 +1,21 @@
-{-# LANGUAGE DeriveAnyClass #-}
-
 module Error where
 
 import AST
 
--- Wrapper for PrettyPrint
-class (PrettyPrint a) => Error a
+data Error = FlowError String | SyntaxError String | UnimplementedError String String | TypeError String BaseType | LookupError LookupErrorCat
+    deriving (Show, Eq)
 
--- Various error types
-newtype FlowError = FlowError String deriving (Eq, Error)
+data LookupErrorCat = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl 
+    deriving (Eq, Show)
 
-newtype SyntaxError = SyntaxError String deriving (Eq, Error)
-
-data UnimplementedError = UnimplementedError String String deriving (Eq, Error)
-
-data TypeError = TypeError String BaseType deriving (Eq, Error)
-
-data LookupError = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl deriving (Eq, Error)
-
--- Definitions of prettyPrint for error types
-instance PrettyPrint FlowError where
+instance PrettyPrint Error where
     prettyPrint (FlowError s) = ["FlowError: " ++ s]
-
-instance PrettyPrint SyntaxError where
     prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
-
-instance PrettyPrint UnimplementedError where
     prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
-
-instance PrettyPrint TypeError where
     prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
-
-instance PrettyPrint LookupError where
-    prettyPrint (LookupErrorVar s) = ["LookupError: Variable " ++ s ++ " is not defined"]
-    prettyPrint (LookupErrorType s) = ["LookupError: Type " ++ s ++ " is not defined"]
-    prettyPrint (LookupErrorTypeDecl (TransformerDecl tx _ _ _)) = ["LookupError: expected type but got transformer" ++ show tx]
+    prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
+    prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
+    prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
 -- dummy values that are returned as proxies when errors are encountered
 dummyBaseType :: BaseType

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -7,3 +7,13 @@ data Error = SyntaxError String
            | LookupError String
            | FlowError String
     deriving (Show, Eq)
+
+-- dummy values that are returned as proxies when errors are encountered
+dummyBaseType :: BaseType
+dummyBaseType = (Named "unknownType__")
+
+dummyDecl :: Decl
+dummyDecl = (TypeDecl "unknownDecl__" [] dummyBaseType)
+
+dummySolExpr :: SolExpr
+dummySolExpr = SolVar "unknownExpr__"

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -10,10 +10,10 @@ data Error = SyntaxError String
 
 -- dummy values that are returned as proxies when errors are encountered
 dummyBaseType :: BaseType
-dummyBaseType = (Named "unknownType__")
+dummyBaseType = Bot
 
 dummyDecl :: Decl
-dummyDecl = (TypeDecl "unknownDecl__" [] dummyBaseType)
+dummyDecl = TypeDecl "unknownDecl__" [] dummyBaseType
 
 dummySolExpr :: SolExpr
 dummySolExpr = SolVar "unknownExpr__"

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -1,13 +1,40 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module Error where
 
 import AST
 
-data Error = SyntaxError String
-           | TypeError String
-           | LookupError String
-           | FlowError String
-           | UnimplementedError String 
-    deriving (Show, Eq)
+-- Wrapper for PrettyPrint
+class (PrettyPrint a) => Error a
+
+-- Various error types
+newtype FlowError = FlowError String deriving (Eq, Error)
+
+newtype SyntaxError = SyntaxError String deriving (Eq, Error)
+
+newtype UnimplementedError = UnimplementedError String deriving (Eq, Error)
+
+data TypeError = TypeError String BaseType deriving (Eq, Error)
+
+data LookupError = LookupErrorVar String | LookupErrorTypeUndefined String | LookupErrorTypeInvalid String Decl deriving (Eq, Error)
+
+-- Definitions of prettyPrint for error types
+instance PrettyPrint FlowError where
+    prettyPrint (FlowError s) = ["FlowError: " ++ s]
+
+instance PrettyPrint SyntaxError where
+    prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
+
+instance PrettyPrint UnimplementedError where
+    prettyPrint (UnimplementedError s) = ["UnimplementedError: " ++ s]
+
+instance PrettyPrint TypeError where
+     prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " for type " ++ show t]
+
+instance PrettyPrint LookupError where
+    prettyPrint (LookupErrorVar s) = ["LookupError: Variable " ++ s ++ " is not defined"]
+    prettyPrint (LookupErrorTypeUndefined s) = ["LookupError: Type " ++ s ++ " is not defined"]
+    prettyPrint (LookupErrorTypeInvalid s d) = ["LookupError: Tried to lookup type declaration" ++ s ++ "but got " ++ show d]
 
 -- dummy values that are returned as proxies when errors are encountered
 dummyBaseType :: BaseType

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -6,6 +6,7 @@ data Error = SyntaxError String
            | TypeError String
            | LookupError String
            | FlowError String
+           | UnimplementedError String 
     deriving (Show, Eq)
 
 -- dummy values that are returned as proxies when errors are encountered

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -1,6 +1,9 @@
 module Error where
 
--- TODO: Add more specific error types
-data Error = ErrorMessage String
-    deriving (Show, Eq)
+import AST
 
+data Error = SyntaxError String
+           | TypeError String
+           | LookupError String
+           | FlowError String
+    deriving (Show, Eq)

--- a/Compiler/test/resources/undefined-type-decl.flow
+++ b/Compiler/test/resources/undefined-type-decl.flow
@@ -1,0 +1,2 @@
+// bogus is not a defined type, should throw LookupError
+1 --> var x : bogus

--- a/Compiler/test/resources/undefined-variable.flow
+++ b/Compiler/test/resources/undefined-variable.flow
@@ -1,0 +1,4 @@
+1 --> var x : nat 
+// y not defined, should result in LookupError
+2 --> y
+


### PR DESCRIPTION
Switched error messages from using Haskell's inbuilt `error` function to a more robust system that does not immediately crash. Introduced an `Error` type as well as a function `addError :: Error -> State Env ()` which appends to a list of errors tracked by the environment. Functions which encounter errors return dummy values so that the compiler can attempt to continue execution. Closes #1.