### PR TITLE
Implement `only when`

### DIFF
--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -26,14 +26,9 @@ compileFile config = do
     case parse parseProgram "" content of
         Left err -> error $ show err
         Right prog -> do
-            let (compiled, env) = runState (compileProg =<< typecheck =<< preprocess prog) newEnv
+            debugPretty config "Parsed program:" prog
 
-            if config^.debug > 0 then do
-                putStrLn "Processed program:"
-                putStrLn $ prettyStr prog
-                putStrLn "========================================================"
-                putStrLn "========================================================"
-            else pure ()
+            let (compiled, env) = runState (compileProg =<< typecheck =<< preprocess prog) newEnv
 
             if not $ null $ env^.errors then do
                 putStrLn "Compilation failed! Errors:"
@@ -48,4 +43,15 @@ compileFile config = do
 
             if config^.debug > 1 then print env
             else pure ()
+
+debugPretty :: PrettyPrint a => Config -> String -> a -> IO a
+debugPretty config message x = do
+    if config^.debug > 0 then do
+        putStrLn message
+        putStrLn $ prettyStr x
+        putStrLn "========================================================"
+        putStrLn "========================================================"
+    else pure ()
+
+    pure x
 

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -32,7 +32,7 @@ compileFile config = do
 
             if not $ null $ env^.errors then do
                 putStrLn "Compilation failed! Errors:"
-                mapM_ print $ env^.errors
+                mapM_ (putStrLn . prettyStr) $ env^.errors
 
             else do
                 if config^.debug > 0 then do

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -38,7 +38,7 @@ data Transformer = Call String [Locator]
                  | Construct String [Locator]
     deriving (Show, Eq)
 
-data Op = OpLt | OpGt | OpLe | OpGe | OpEq | OpNe | OpIn
+data Op = OpLt | OpGt | OpLe | OpGe | OpEq | OpNe | OpIn | OpNotIn
     deriving (Show, Eq)
 
 data Precondition = Conj [Precondition]
@@ -151,6 +151,7 @@ instance PrettyPrint Op where
     prettyPrint OpEq = ["="]
     prettyPrint OpNe = ["!="]
     prettyPrint OpIn = ["in"]
+    prettyPrint OpNotIn = ["not in"]
 
 instance PrettyPrint Precondition where
     prettyPrint (Conj conds) = [ intercalate " and " (map (\cond -> "(" ++ prettyStr cond ++ ")") conds) ]

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -42,7 +42,9 @@ data Op = OpLt | OpGt | OpLe | OpGe | OpEq | OpNe | OpIn
     deriving (Show, Eq)
 
 data Precondition = Conj [Precondition]
+                  | Disj [Precondition]
                   | BinOp Op Locator Locator
+                  | NegateCond Precondition
     deriving (Show, Eq)
 
 data Stmt = Flow Locator Locator
@@ -151,8 +153,10 @@ instance PrettyPrint Op where
     prettyPrint OpIn = ["in"]
 
 instance PrettyPrint Precondition where
-    prettyPrint (Conj conds) = [ intercalate " and " (map prettyStr conds) ]
+    prettyPrint (Conj conds) = [ intercalate " and " (map (\cond -> "(" ++ prettyStr cond ++ ")") conds) ]
+    prettyPrint (Disj conds) = [ intercalate " or " (map (\cond -> "(" ++ prettyStr cond ++ ")") conds) ]
     prettyPrint (BinOp op a b) = [ prettyStr a ++ " " ++ prettyStr op ++ " " ++ prettyStr b ]
+    prettyPrint (NegateCond cond) = [ "!(" ++ prettyStr cond ++ ")" ]
 
 instance PrettyPrint Stmt where
     prettyPrint (Flow src dst) = [ prettyStr src ++ " --> " ++ prettyStr dst ]

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -79,6 +79,7 @@ data SolExpr = SolBool Bool
              | SolVar String
              | FieldAccess SolExpr String
              | SolPostInc SolExpr
+             | SolNot SolExpr
              | SolCall SolExpr [SolExpr]
              | SolIdx SolExpr SolExpr
              | SolAdd SolExpr SolExpr
@@ -198,7 +199,7 @@ instance PrettyPrint Decl where
     prettyPrint (TypeDecl name ms baseT) =
         [ "type " ++ name ++ " is " ++ unwords (map prettyStr ms) ++ " " ++ prettyStr baseT ]
     prettyPrint (TransformerDecl name args ret body) =
-        [ "transformer " ++ name ++ "(" ++ intercalate ", " (map prettyStr args) ++ ") -> " ++ prettyStr ret ++ "{"]
+        [ "transformer " ++ name ++ "(" ++ intercalate ", " (map prettyStr args) ++ ") -> " ++ prettyStr ret ++ " {"]
         ++ concatMap (map indent . prettyPrint) body
         ++ [ "}" ]
 
@@ -214,6 +215,7 @@ instance PrettyPrint SolExpr where
     prettyPrint (SolVar x) = [ x ]
     prettyPrint (FieldAccess e x) = [ prettyStr e ++ "." ++ x ]
     prettyPrint (SolPostInc e) = [ prettyStr e ++ "++" ]
+    prettyPrint (SolNot e) = [ "!" ++ "(" ++ prettyStr e ++ ")" ]
     prettyPrint (SolCall recv args) = [ prettyStr recv ++ "(" ++ intercalate ", " (map prettyStr args) ++ ")" ]
     prettyPrint (SolIdx e idxE) = [ prettyStr e ++ "[" ++ prettyStr idxE ++ "]" ]
     prettyPrint (SolAdd e1 e2) = [ "(" ++ prettyStr e1 ++ ") + (" ++ prettyStr e2 ++ ")" ]

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -175,6 +175,8 @@ compileStmt (Try tryBlock catchBlock) = do
                     unpackClosureBlock
                     catchCompiled ]
 
+compileStmt Revert = pure [ SolRevert (SolStr "REVERT") ]
+
 makeConstructor :: String -> State Env ([SolExpr] -> SolExpr)
 makeConstructor t = do
     decl <- lookupTypeDecl t

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 
 module Env where
 
-import Control.Lens (makeLenses, over, (<<+=))
+import Control.Lens (makeLenses, over, (<<+=), view)
 import Control.Monad.State
 
 import Data.Map (Map)
@@ -34,4 +35,104 @@ freshName = do
 
 addError :: Error -> State Env ()
 addError e = modify $ over errors (e:)
+
+lookupTypeDecl :: String -> State Env Decl
+lookupTypeDecl typeName = do
+    decl <- Map.lookup typeName . view declarations <$> get
+    case decl of
+        Nothing -> do
+            addError $ LookupError (LookupErrorType typeName)
+            pure dummyDecl
+        Just tx@TransformerDecl{} -> do
+            addError $ LookupError (LookupErrorTypeDecl tx)
+            pure dummyDecl
+        Just tdec@TypeDecl{} -> pure tdec
+
+modifiers :: String -> State Env [Modifier]
+modifiers typeName = do
+    decl <- lookupTypeDecl typeName
+    case decl of
+        TypeDecl _ mods _ -> pure mods
+
+typeOf :: String -> State Env BaseType
+typeOf x = do
+    maybeT <- Map.lookup x . view typeEnv <$> get
+    case maybeT of
+        Nothing -> do
+            addError $ LookupError (LookupErrorVar x)
+            pure dummyBaseType
+        Just t -> pure t
+
+typeOfLoc :: Locator -> State Env BaseType
+typeOfLoc (IntConst _) = pure Nat
+typeOfLoc (BoolConst _) = pure PsaBool
+typeOfLoc (StrConst _) = pure PsaString
+typeOfLoc (AddrConst _) = pure Address
+typeOfLoc (Var x) = typeOf x
+typeOfLoc (Multiset t _) = pure $ Table [] t
+typeOfLoc (Select l k) = do
+    lTy <- typeOfLoc l
+    kTy <- typeOfLoc k
+    keyTypesL <- keyTypes lTy
+
+    if kTy `elem` keyTypesL then
+        pure $ valueType lTy
+    else
+        pure lTy
+typeOfLoc (Field l x) = do
+    lTy <- typeOfLoc l
+    lookupField lTy x
+
+lookupField :: BaseType -> String -> State Env BaseType
+lookupField t@(Record key fields) x =
+    case [ t | (y,(_,t)) <- fields, x == y ] of
+        [] -> do
+            addError $ FieldNotFoundError x t
+            pure Bot
+        (fieldTy:_) -> pure fieldTy
+lookupField (Named t) x = do
+    decl <- lookupTypeDecl t
+    case decl of
+        TypeDecl _ _ baseT -> lookupField baseT x
+
+keyTypes :: BaseType -> State Env [BaseType]
+keyTypes Nat = pure [Nat]
+keyTypes PsaBool = pure [PsaBool]
+keyTypes PsaString = pure [PsaString]
+keyTypes Address = pure [Address]
+keyTypes (Named t) = do
+    demotedT <- demoteBaseType (Named t)
+    pure [Named t, demotedT]
+keyTypes t@(Table ["key"] (One, Record ["key"] [ ("key", (_,keyTy)), ("value", (_,valueTy)) ])) = pure [t, keyTy]
+keyTypes (Table keys t) = pure [Table keys t]
+keyTypes (Record keys fields) = pure $ Record keys fields : [ t | (x,(_,t)) <- fields, x `elem` keys ]
+
+valueType :: BaseType -> BaseType
+valueType Nat = Nat
+valueType PsaBool = PsaBool
+valueType PsaString = PsaString
+valueType Address = Address
+valueType (Named t) = Named t
+valueType (Table ["key"] (One, Record ["key"] [ ("key", (_,keyTy)), ("value", (_,valueTy)) ])) = valueTy
+valueType (Table keys t) = Table keys t
+valueType (Record keys fields) =
+    case [ (x,t) | (x,t) <- fields, x `notElem` keys ] of
+        [ (_,(_,t)) ] -> t
+        fields -> Record [] fields
+
+demoteBaseType :: BaseType -> State Env BaseType
+demoteBaseType Nat = pure Nat
+demoteBaseType PsaBool = pure PsaBool
+demoteBaseType PsaString = pure PsaString
+demoteBaseType Address = pure Address
+demoteBaseType (Table keys (q, t)) = Table keys . (q,) <$> demoteBaseType t
+demoteBaseType (Record keys fields) = Record keys <$> mapM (\(x, (q,t)) -> (x,) . (q,) <$> demoteBaseType t) fields
+demoteBaseType (Named t) = do
+    decl <- lookupTypeDecl t
+    case decl of
+        TypeDecl _ _ baseT -> demoteBaseType baseT
+demoteBaseType Bot = pure Bot
+
+demoteType :: Type -> State Env Type
+demoteType (q, t) = (q,) <$> demoteBaseType t
 

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -34,3 +34,4 @@ freshName = do
 
 addError :: Error -> State Env ()
 addError e = modify $ over errors (e:)
+

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -27,6 +27,9 @@ instance PrettyPrint Error where
 dummyBaseType :: BaseType
 dummyBaseType = Bot
 
+dummyType :: Type
+dummyType = (Any, Bot)
+
 dummyDecl :: Decl
 dummyDecl = TypeDecl "unknownDecl__" [] dummyBaseType
 

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -2,10 +2,15 @@ module Error where
 
 import AST
 
-data Error = FlowError String | SyntaxError String | UnimplementedError String String | TypeError String BaseType | LookupError LookupErrorCat
+data Error = FlowError String
+           | SyntaxError String
+           | UnimplementedError String String
+           | TypeError String BaseType
+           | FieldNotFoundError String BaseType
+           | LookupError LookupErrorCat
     deriving (Show, Eq)
 
-data LookupErrorCat = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl 
+data LookupErrorCat = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl
     deriving (Eq, Show)
 
 instance PrettyPrint Error where
@@ -13,6 +18,7 @@ instance PrettyPrint Error where
     prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
     prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
     prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
+    prettyPrint (FieldNotFoundError x t) = ["FieldNotFoundError: Field " ++ x ++ " not found in type " ++ show t]
     prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
     prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]

--- a/Compiler/src/Parser.hs
+++ b/Compiler/src/Parser.hs
@@ -87,7 +87,7 @@ parseOnlyWhen = do
 
 parsePrecondition :: Parser Precondition
 parsePrecondition = do
-    ops <- binOpCond `sepBy1` (symbol (string "and"))
+    ops <- binOpCond `sepEndBy1` try (symbol (string "and"))
     case ops of
         [] -> error "Impossible!" -- b/c we use sepBy1
         [x] -> pure x

--- a/Compiler/src/Parser.hs
+++ b/Compiler/src/Parser.hs
@@ -113,11 +113,13 @@ binOpCond :: Parser Precondition
 binOpCond = do
     a <- parseLocator
     op <- symbol $ choice $ map try [ parseConst "<=" OpLe, parseConst "<" OpLt,
-                                      parseConst ">=" OpGt, parseConst ">" OpGt,
+                                      parseConst ">=" OpGe, parseConst ">" OpGt,
                                       parseConst "=" OpEq, parseConst "!=" OpNe,
-                                      parseConst "in" OpIn ]
+                                      parseConst "in" OpIn, parseNotIn ]
     b <- parseLocator
     pure $ BinOp op a b
+    where
+        parseNotIn = symbol (string "not") >> symbol (string "in") >> pure OpNotIn
 
 parseFlow :: Parser Stmt
 parseFlow = do

--- a/Compiler/src/Parser.hs
+++ b/Compiler/src/Parser.hs
@@ -96,8 +96,8 @@ parsePrecondition = do
 binOpCond :: Parser Precondition
 binOpCond = do
     a <- parseLocator
-    op <- symbol $ choice $ map try [ parseConst "<" OpLt, parseConst "<=" OpLe,
-                                      parseConst ">" OpGt, parseConst ">=" OpGe,
+    op <- symbol $ choice $ map try [ parseConst "<=" OpLe, parseConst "<" OpLt,
+                                      parseConst ">=" OpGt, parseConst ">" OpGt,
                                       parseConst "=" OpEq, parseConst "!=" OpNe,
                                       parseConst "in" OpIn ]
     b <- parseLocator

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -13,6 +13,9 @@ preprocess (Program decls stmts) =
             <*> (concat <$> mapM preprocessStmt stmts)
 
 preprocessDecl :: Decl -> State Env [Decl]
+preprocessDecl (TransformerDecl name args ret body) = do
+    newBody <- concat <$> mapM preprocessStmt body
+    pure [TransformerDecl name args ret newBody]
 preprocessDecl d = pure [d]
 
 -- TODO: Might need to make this more flexible, in case we need to generate declarations or something

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -4,6 +4,7 @@ import Control.Monad.State
 
 import AST
 import Env
+import Error
 
 -- TODO: Probably want to have multiple AST types for better type safety
 preprocess :: Program -> State Env Program
@@ -16,5 +17,38 @@ preprocessDecl d = pure [d]
 
 -- TODO: Might need to make this more flexible, in case we need to generate declarations or something
 preprocessStmt :: Stmt -> State Env [Stmt]
+preprocessStmt (OnlyWhen cond) = preprocessCond cond
 preprocessStmt s = pure [s]
+
+-- TODO: We need to ensure that these conditions are all valid. E.g., something like
+-- only when 1 < 2
+-- technically makes sense, but gets compiled to
+-- 2 --[ 1 ]-> 2
+-- which is invalid (2 is not a valid destination)
+preprocessCond :: Precondition -> State Env [Stmt]
+preprocessCond (Conj conds) = concat <$> mapM preprocessCond conds
+preprocessCond (BinOp OpLt a b) = pure [ Flow (Select b a) b ]
+preprocessCond (BinOp OpGt a b) = preprocessCond (BinOp OpLt b a)
+preprocessCond (BinOp OpEq a b) = pure [ Flow (Select a b) a, Flow (Select b a) b ]
+-- NOTE: This is implemented the same as OpLt, but exists
+--       basically in case people aren't comfortable considering
+--       multiset ordering as a kind of less-than...which I guess is likely
+preprocessCond (BinOp OpIn a b) = pure [ Flow (Select b a) b ]
+preprocessCond (BinOp OpNe a b) = do
+    v <- Var <$> freshName
+    failure <- preprocessCond (BinOp OpEq a b)
+    pure [Try (failure ++ [ Revert ]) []]
+-- TODO: We need to be able to write things like "x + 1" in locators for this to work out nicely (alternatively, we could compile things like:
+-- only when a <= b
+-- into
+-- b --[ a ]-> var temp : t
+-- b --[ 1 ]-> temp
+-- temp --> b
+-- But that's kind of annoying
+preprocessCond cond@(BinOp OpLe a b) = do
+    addError $ UnimplementedError "only when" $ show cond
+    pure []
+preprocessCond cond@(BinOp OpGe a b) = do
+    addError $ UnimplementedError "only when" $ show cond
+    pure []
 

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -17,7 +17,7 @@ main = hspec $ do
 preprocessorTests = do
     describe "preprocessCond" $ do
         it "expands simple preconditions" $ do
-            evalState (preprocessCond (BinOp OpLt (Var "x") (Var "y"))) newEnv
+            evalState (preprocessCond (BinOp OpLte (Var "x") (Var "y"))) newEnv
                 `shouldBe` [Flow (Select (Var "y") (Var "x")) (Var "y")]
 
             evalState (preprocessCond (BinOp OpEq (Select (Var "x") (Var "vs")) (Var "y"))) newEnv

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -1,37 +1,79 @@
+import Control.Monad.State
+
 import Test.Hspec
 
 import Text.Parsec
 
 import AST
+import Env
+import Preprocessor
 import Parser
 
 main :: IO ()
 main = hspec $ do
+    preprocessorTests
     parserTests
+
+preprocessorTests = do
+    describe "preprocessCond" $ do
+        it "expands simple preconditions" $ do
+            evalState (preprocessCond (BinOp OpLt (Var "x") (Var "y"))) newEnv
+                `shouldBe` [Flow (Select (Var "y") (Var "x")) (Var "y")]
+
+            evalState (preprocessCond (BinOp OpEq (Select (Var "x") (Var "vs")) (Var "y"))) newEnv
+                `shouldBe` [Flow (Select (Select (Var "x") (Var "vs")) (Var "y")) (Select (Var "x") (Var "vs")),
+                            Flow (Select (Var "y") (Select (Var "x") (Var "vs"))) (Var "y")]
+
+        it "expands conjunctions of preconditions" $ do
+            evalState (preprocessCond (Conj [BinOp OpNe (Var "x") (Var "y"), BinOp OpIn (Var "x") (Multiset (Any,Nat) [ IntConst 0, IntConst 1 ])])) newEnv
+                `shouldBe` [Try [Flow (Select (Var "x") (Var "y")) (Var "x"),
+                                 Flow (Select (Var "y") (Var "x")) (Var "y"),
+                                 Revert] [],
+                            Flow (Select (Multiset (Any,Nat) [IntConst 0,IntConst 1]) (Var "x")) (Multiset (Any,Nat) [IntConst 0,IntConst 1])]
 
 parserTests = do
     describe "parseStmt" $ do
         it "parses simple flows" $ do
-            parse parseStmt "" "x --> y" `shouldBe` Right (Flow (Var "x") (Var "y"))
-            parse parseStmt "" "[ any nat ; ] --> var m : map any nat => any nat" `shouldBe` Right (Flow (Multiset (Any,Nat) []) (NewVar "m" (Table ["key"] (One,Record ["key"] [("key",(Any,Nat)),("value",(Any,Nat))]))))
+            parse parseStmt "" "x --> y"
+                `shouldBe` Right (Flow (Var "x") (Var "y"))
+            parse parseStmt "" "[ any nat ; ] --> var m : map any nat => any nat"
+                `shouldBe` Right (Flow (Multiset (Any,Nat) []) (NewVar "m" (Table ["key"] (One,Record ["key"] [("key",(Any,Nat)),("value",(Any,Nat))]))))
         it "parses simple backwards flows" $
-            parse parseStmt "" "y <-- 1" `shouldBe` Right (Flow (IntConst 1) (Var "y"))
+            parse parseStmt "" "y <-- 1"
+                `shouldBe` Right (Flow (IntConst 1) (Var "y"))
 
         it "parses transformer flows" $
-            parse parseStmt "" "x --> f() --> var t : nat" `shouldBe` Right (FlowTransform (Var "x") (Call "f" []) (NewVar "t" Nat))
+            parse parseStmt "" "x --> f() --> var t : nat"
+                `shouldBe` Right (FlowTransform (Var "x") (Call "f" []) (NewVar "t" Nat))
         it "parses backwards transformer flows" $
-            parse parseStmt "" "var ts : multiset any nat <-- g(y) <-- [ any nat; ]" `shouldBe` Right (FlowTransform (NewVar "ts" (Table [] (Any,Nat))) (Call "g" [Var "y"]) (Multiset (Any,Nat) []))
+            parse parseStmt "" "var ts : multiset any nat <-- g(y) <-- [ any nat; ]"
+                `shouldBe` Right (FlowTransform (NewVar "ts" (Table [] (Any,Nat))) (Call "g" [Var "y"]) (Multiset (Any,Nat) []))
 
         it "parses try-catch statements" $
-            parse parseStmt "" "try {} catch {}" `shouldBe` Right (Try [] [])
+            parse parseStmt "" "try {} catch {}"
+                `shouldBe` Right (Try [] [])
 
         it "parses flows with selector arrow" $
-            parse parseStmt "" "x --[ 5 ]-> y" `shouldBe` Right (Flow (Select (Var "x") (IntConst 5)) (Var "y"))
+            parse parseStmt "" "x --[ 5 ]-> y"
+                `shouldBe` Right (Flow (Select (Var "x") (IntConst 5)) (Var "y"))
         it "parses backwards flows with selector arrow" $
-            parse parseStmt "" "var t : bool <-[ z ]-- [ any bool; true, false] " `shouldBe` Right (Flow (Select (Multiset (Any,PsaBool) [BoolConst True,BoolConst False]) (Var "z")) (NewVar "t" PsaBool))
+            parse parseStmt "" "var t : bool <-[ z ]-- [ any bool; true, false] "
+                `shouldBe` Right (Flow (Select (Multiset (Any,PsaBool) [BoolConst True,BoolConst False]) (Var "z")) (NewVar "t" PsaBool))
 
         it "parses flows with filters" $ do
-            parse parseStmt "" "A --[ nonempty such that isWinner(winNum) ]-> var winners : mutliset one Ticket" `shouldBe` Right (Flow (Filter (Var "A") Nonempty "isWinner" [Var "winNum"]) (NewVar "winners" (Named "mutliset")))
+            parse parseStmt "" "A --[ nonempty such that isWinner(winNum) ]-> var winners : mutliset one Ticket"
+                `shouldBe` Right (Flow (Filter (Var "A") Nonempty "isWinner" [Var "winNum"]) (NewVar "winners" (Named "mutliset")))
         it "parses backwards flows with filters" $ do
-            parse parseStmt "" "vals <-[ any such that nonzero() ]-- src" `shouldBe` Right (Flow (Filter (Var "src") Any "nonzero" []) (Var "vals"))
+            parse parseStmt "" "vals <-[ any such that nonzero() ]-- src"
+                `shouldBe` Right (Flow (Filter (Var "src") Any "nonzero" []) (Var "vals"))
+
+        it "parses preconditions" $ do
+            parse parseStmt "" "only when 1 < 2"
+                `shouldBe` Right (OnlyWhen (BinOp OpLt (IntConst 1) (IntConst 2)))
+            parse parseStmt "" "only when x = y and z in w"
+                `shouldBe` Right (OnlyWhen (Conj [BinOp OpEq (Var "x") (Var "y"), BinOp OpIn (Var "z") (Var "w")]))
+
+        it "parses revert" $ do
+            parse parseStmt "" "revert"
+                `shouldBe` Right Revert
 

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -17,7 +17,7 @@ main = hspec $ do
 preprocessorTests = do
     describe "preprocessCond" $ do
         it "expands simple preconditions" $ do
-            evalState (preprocessCond (BinOp OpLte (Var "x") (Var "y"))) newEnv
+            evalState (preprocessCond (BinOp OpLe (Var "x") (Var "y"))) newEnv
                 `shouldBe` [Flow (Select (Var "y") (Var "x")) (Var "y")]
 
             evalState (preprocessCond (BinOp OpEq (Select (Var "x") (Var "vs")) (Var "y"))) newEnv

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -46,6 +46,11 @@ preprocessorTests = do
                 `shouldBeStmts` unlines ["x[vs] --[ y ]-> x[vs]",
                                          "y --[ x[vs] ]-> y"]
 
+            evalEnv newEnv (preprocessCond (BinOp OpLe (IntConst 1) (IntConst 3)))
+                `shouldBeStmts` unlines ["1 --> var v0 : nat",
+                                         "3 --> var v1 : nat",
+                                         "v1 --[ v0 ]-> v1"]
+
         it "expands conjunctions of preconditions" $ do
             evalEnv newEnv (preprocessCond (Conj [BinOp OpNe (Var "x") (Var "y"), BinOp OpIn (Var "x") (Multiset (Any,Nat) [ IntConst 0, IntConst 1 ])]))
                 `shouldBeStmts` unlines ["try {",
@@ -53,7 +58,8 @@ preprocessorTests = do
                                          "    y --[ x ]-> y",
                                          "    revert",
                                          "} catch {}",
-                                         "[ any nat; 0,1 ] --[ x ]-> [ any nat; 0,1 ]"]
+                                         "[ any nat; 0,1 ] --> var v1 : multiset any nat",
+                                         "v1 --[ x ]-> v1"]
 
 parserTests = do
     describe "parseStmt" $ do

--- a/Compiler/test/resources/preconditions.flow
+++ b/Compiler/test/resources/preconditions.flow
@@ -14,5 +14,5 @@ transformer giveRightToVote(this : one Election, sender : one address, voter : o
 [ any nat ; 1,2 ] --> var y : multiset any nat
 10 --> var z : nat
 
-only when x in y and x < z
+only when x in y and x <= z
 

--- a/Compiler/test/resources/preconditions.flow
+++ b/Compiler/test/resources/preconditions.flow
@@ -10,3 +10,9 @@ transformer giveRightToVote(this : one Election, sender : one address, voter : o
     voter --> new Voter() --> this.eligibleVoters
 }
 
+1 --> var x : nat
+[ any nat ; 1,2 ] --> var y : multiset any nat
+10 --> var z : nat
+
+only when x in y and x < z
+

--- a/Compiler/test/resources/preconditions.flow
+++ b/Compiler/test/resources/preconditions.flow
@@ -1,0 +1,12 @@
+type Voter is unique immutable asset address
+
+type Election is asset {
+    chairperson : one address,
+    eligibleVoters : any list one Voter
+}
+
+transformer giveRightToVote(this : one Election, sender : one address, voter : one address) {
+    only when sender = this.chairperson
+    voter --> new Voter() --> this.eligibleVoters
+}
+

--- a/flow.vim
+++ b/flow.vim
@@ -41,7 +41,7 @@ syntax keyword constWords true false
 syntax region string start='"' end='"' skip='\\"'
 syntax region string start='\'' end='\'' skip='\\\''
 
-syntax keyword type nat int bool bytes address string ether uint256 set linking map option list link mapitem
+syntax keyword type nat int bool bytes address string ether uint256 set linking map option list multiset link mapitem
 
 syntax keyword contract contract state storage source sink pool interface
 syntax keyword contractModifiers main


### PR DESCRIPTION
This implements the `only when` statement, adding nicer precondition syntax (see #9). As an example, consider the following file (see `test/resources/preconditions.flow`):
```
type Voter is unique immutable asset address

type Election is asset {
    chairperson : one address,
    eligibleVoters : any list one Voter
}

transformer giveRightToVote(this : one Election, sender : one address, voter : one address) {
    only when sender = this.chairperson
    voter --> new Voter() --> this.eligibleVoters
}

1 --> var x : nat
[ any nat ; 1,2 ] --> var y : multiset any nat
10 --> var z : nat

only when x in y and x <= z
```
This compiles to:
```
// SPDX-License-Identifier: MIT
pragma solidity ^0.7.5;
contract C {
    uint[][] v0;
    struct Election {
        bool initialized;
        address chairperson;
        address[] eligibleVoters;
    }
    function giveRightToVote(Election storage this, address sender, address voter) internal returns (bool __success) {
        require((sender) == (this.chairperson), "FAILED TO SELECT");
        require((this.chairperson) == (sender), "FAILED TO SELECT");
        this.eligibleVoters.push(voter);
        delete voter;
        __success = (__success) || (true);
    }
    constructor () {
        uint x;
        require((x) <= ((x) + (1)), "OVERFLOW");
        x = (x) + (1);
        uint[] storage y = v0.push();
        y.push(1);
        y.push(2);
        uint z;
        require((z) <= ((z) + (10)), "OVERFLOW");
        z = (z) + (10);
        for (uint v1 = 0; (v1) < (y.length); v1++) {
            if ((y[v1]) == (x)) {
                y.push(y[v1]);
                delete y[v1];
            }
        }
        require((x) <= (z), "UNDERFLOW");
        require((z) <= ((z) + (x)), "OVERFLOW");
        z = (z) + (x);
        z = (z) - (x);
    }
}
```

Notes:
- See #16 for future plans to extend this code/remove some redundant operations in the generated code.
- Currently `<` and `>` are not actually supported: see #19.

Closes #9.