### PR TITLE
Type quantity inference

### DIFF
--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -24,9 +24,6 @@ import Config
 main :: IO ()
 main = compileFile =<< getArgs
 
-(>>>) :: (ProgramTransform p1 p2, PhaseTransition p1 p1) => (a, Env p1) -> (a -> State (Env p2) b) -> (b, Env p2)
-(a, s) >>> f = runState (f a) (transformEnv s)
-
 compileFile :: Config -> IO ()
 compileFile config = do
     content <- obtainContent config

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -14,6 +14,7 @@ import AST
 import Compiler
 import Env
 import Parser
+import Phase
 import Preprocessor
 import Transform
 import Typechecker
@@ -23,7 +24,7 @@ import Config
 main :: IO ()
 main = compileFile =<< getArgs
 
-(>>>) :: ProgramTransform p1 p2 => (a, Env p1) -> (a -> State (Env p2) b) -> (b, Env p2)
+(>>>) :: (ProgramTransform p1 p2, PhaseTransition p1 p1) => (a, Env p1) -> (a -> State (Env p2) b) -> (b, Env p2)
 (a, s) >>> f = runState (f a) (transformEnv s)
 
 compileFile :: Config -> IO ()

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -40,7 +40,7 @@ compileFile config = do
             if not $ null $ env^.errors then do
                 putError "Compilation failed!"
                 putError "-------------------"
-                putError $ prettyStr (view errors env)
+                putError $ prettyStr $ env^.errors
                 exitFailure
             else do
                 if config^.debug > 0 then do

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -8,6 +8,7 @@ import Control.Monad
 
 import Text.Parsec (parse)
 
+import System.IO (hPutStrLn, stderr)
 import System.Exit
 
 import AST
@@ -24,6 +25,8 @@ import Config
 main :: IO ()
 main = compileFile =<< getArgs
 
+putError = hPutStrLn stderr
+
 compileFile :: Config -> IO ()
 compileFile config = do
     content <- obtainContent config
@@ -35,8 +38,9 @@ compileFile config = do
             let (compiled, env) = runState (preprocess prog) newEnv >>> typecheck >>> compileProg
 
             if not $ null $ env^.errors then do
-                putStrLn "Compilation failed! Errors:"
-                putStrLn $ prettyStr (view errors env)
+                putError "Compilation failed!"
+                putError "-------------------"
+                putError $ prettyStr (view errors env)
                 exitFailure
             else do
                 if config^.debug > 0 then do

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -35,7 +35,7 @@ compileFile config = do
         Right prog -> do
             debugPretty config "Parsed program:" prog
 
-            let (compiled, env) = runState (preprocess prog) newEnv >>> typecheck >>> compileProg
+            let (compiled, env) = runState (preprocess prog) (newEnv Preprocessor) >>> typecheck >>> compileProg
 
             if not $ null $ env^.errors then do
                 putError "Compilation failed!"

--- a/Compiler/app/Main.hs
+++ b/Compiler/app/Main.hs
@@ -38,7 +38,7 @@ compileFile config = do
 
             if not $ null $ env^.errors then do
                 putStrLn "Compilation failed! Errors:"
-                mapM_ (putStrLn . prettyStr) $ env^.errors
+                putStrLn $ prettyStr (view errors env)
                 exitFailure
             else do
                 if config^.debug > 0 then do

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -25,20 +25,20 @@ class DefinesXType p where
     extractBaseType :: XType p -> BaseType p
     replaceBaseType :: XType p -> BaseType p -> XType p
 
-instance DefinesXType Parsed where
-    type XType Parsed = InferrableType Parsed
+instance DefinesXType Preprocessing where
+    type XType Preprocessing = InferrableType Preprocessing
     extractBaseType (Complete (q, t)) = t
     extractBaseType (Infer t) = t
     replaceBaseType (Complete (q, _)) t = Complete (q, t)
     replaceBaseType (Infer _) t = Infer t
 
-instance DefinesXType Preprocessed where
-    type XType Preprocessed = QuantifiedType Preprocessed
+instance DefinesXType Typechecking where
+    type XType Typechecking = QuantifiedType Typechecking
     extractBaseType (q, t) = t
     replaceBaseType (q, _) t = (q, t)
 
-instance DefinesXType Typechecked where
-    type XType Typechecked = QuantifiedType Typechecked
+instance DefinesXType Compiling where
+    type XType Compiling = QuantifiedType Compiling
     extractBaseType (q, t) = t
     replaceBaseType (q, _) t = (q, t)
 

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -158,58 +157,6 @@ deriving instance Show (XType phase) => Show (Precondition phase)
 deriving instance Show (XType phase) => Show (Stmt phase)
 deriving instance Show (XType phase) => Show (Decl phase)
 deriving instance Show (XType phase) => Show (Program phase)
-
--- AST transforms
-class ProgramTransform a b where
-    transformXType :: XType a -> XType b
-
-transformBaseType :: forall a b. ProgramTransform a b => BaseType a -> BaseType b
-transformBaseType Nat = Nat
-transformBaseType PsaBool = PsaBool
-transformBaseType PsaString = PsaString
-transformBaseType Address = Address
-transformBaseType (Record keys fields) = Record keys (map transformVarDef fields)
-transformBaseType (Table keys t) = Table keys (transformXType @a @b t)
-transformBaseType (Named name) = Named name
-transformBaseType Bot = Bot
-
-transformQuantifiedType :: forall a b. ProgramTransform a b => QuantifiedType a -> QuantifiedType b
-transformQuantifiedType (q, t) = (q, transformBaseType t)
-
-transformVarDef :: forall a b. ProgramTransform a b => VarDef a -> VarDef b
-transformVarDef (VarDef name t) = VarDef name (transformXType @a @b t)
-
-transformLocator :: forall a b. ProgramTransform a b => Locator a -> Locator b
-transformLocator (IntConst i) = IntConst i
-transformLocator (StrConst s) = StrConst s
-transformLocator (AddrConst addr) = AddrConst addr
-transformLocator (Var var) = Var var
-transformLocator (Field l name) = Field (transformLocator l) name
-transformLocator (Multiset t locators) = Multiset (transformXType @a @b t) (map transformLocator locators)
-transformLocator (NewVar name baseT) = NewVar name (transformBaseType baseT)
-transformLocator (Filter l q predName args) = Filter (transformLocator l) q predName (map transformLocator args)
-transformLocator (Select l k) = Select (transformLocator l) (transformLocator k)
-
-transformTransformer :: ProgramTransform a b => Transformer a -> Transformer b
-transformTransformer (Construct name args) = Construct name (map transformLocator args)
-transformTransformer (Call name args) = Call name (map transformLocator args)
-
-transformPrecondition :: ProgramTransform a b => Precondition a -> Precondition b
-transformPrecondition (Conj conds) = Conj (map transformPrecondition conds)
-transformPrecondition (Disj conds) = Disj (map transformPrecondition conds)
-transformPrecondition (BinOp op a b) = BinOp op (transformLocator a) (transformLocator b)
-transformPrecondition (NegateCond cond) = NegateCond (transformPrecondition cond)
-
-transformStmt :: ProgramTransform a b => Stmt a -> Stmt b
-transformStmt (Flow src dst) = Flow (transformLocator src) (transformLocator dst)
-transformStmt (FlowTransform src transformer dst) = FlowTransform (transformLocator src) (transformTransformer transformer) (transformLocator dst)
-transformStmt (OnlyWhen precondition) = OnlyWhen (transformPrecondition precondition)
-transformStmt Revert = Revert
-transformStmt (Try checkC1 checkCs) = Try (map transformStmt checkC1) (map transformStmt checkCs)
-
-transformDecl :: ProgramTransform a b => Decl a -> Decl b
-transformDecl (TypeDecl s modifiers baseT) = TypeDecl s modifiers (transformBaseType baseT)
-transformDecl (TransformerDecl name args ret body) = TransformerDecl name (map transformVarDef args) (transformVarDef ret) (map transformStmt body)
 
 -- PrettyPrint definitions for all the AST types
 class PrettyPrint a where

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module AST where

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,17 +12,13 @@ module AST where
 import Data.Char (toLower)
 import Data.List (intercalate)
 
+import Phase
+
 data Modifier = Fungible | Immutable | Consumable | Asset | Unique
     deriving (Show, Eq)
 
 data TyQuant = Empty | Any | One | Nonempty
     deriving (Show, Eq)
-
--- Compiler phases
-data Parsed
-data Preprocessed
-data Typechecked
-data Compiled
 
 class DefinesXType p where
     type XType p    :: *

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -25,7 +25,7 @@ data TyQuant = Empty | Any | One | Nonempty
     deriving (Show, Eq)
 
 type family XType phase :: * where
-    XType Preprocessed = InferrableType Preprocessed
+    XType Parsed = InferrableType Parsed
     XType phase = QuantifiedType phase
 
 data BaseType phase = Nat | PsaBool | PsaString | Address

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -44,50 +44,50 @@ instance DefinesXType Compiling where
 
 -- AST types, parameterized by compiler phase
 data BaseType phase = Nat | PsaBool | PsaString | Address
-              | Record [String] [VarDef phase]
-              | Table [String] (XType phase)
-              | Named String
-              | Bot
+                    | Record [String] [VarDef phase]
+                    | Table [String] (XType phase)
+                    | Named String
+                    | Bot
 
 type QuantifiedType phase = (TyQuant, BaseType phase)
 
 data InferrableType phase = Complete (QuantifiedType phase)
-                    | Infer (BaseType phase)
+                          | Infer (BaseType phase)
 
 data VarDef phase = VarDef String (XType phase)
 
 data Locator phase = IntConst Integer
-             | BoolConst Bool
-             | StrConst String
-             | AddrConst String
-             | Var String
-             | Field (Locator phase) String
-             | Multiset (XType phase) [Locator phase]
-             | NewVar String (BaseType phase)
-             | Consume
-             | RecordLit [String] [(VarDef phase, Locator phase)]
-             | Filter (Locator phase) TyQuant String [Locator phase]
-             | Select (Locator phase) (Locator phase)
+                   | BoolConst Bool
+                   | StrConst String
+                   | AddrConst String
+                   | Var String
+                   | Field (Locator phase) String
+                   | Multiset (XType phase) [Locator phase]
+                   | NewVar String (BaseType phase)
+                   | Consume
+                   | RecordLit [String] [(VarDef phase, Locator phase)]
+                   | Filter (Locator phase) TyQuant String [Locator phase]
+                   | Select (Locator phase) (Locator phase)
 
 data Transformer phase = Call String [Locator phase]
-                 | Construct String [Locator phase]
+                       | Construct String [Locator phase]
 
 data Op = OpLt | OpGt | OpLe | OpGe | OpEq | OpNe | OpIn | OpNotIn
     deriving (Show, Eq)
 
 data Precondition phase = Conj [Precondition phase]
-                  | Disj [Precondition phase]
-                  | BinOp Op (Locator phase) (Locator phase)
-                  | NegateCond (Precondition phase)
+                        | Disj [Precondition phase]
+                        | BinOp Op (Locator phase) (Locator phase)
+                        | NegateCond (Precondition phase)
 
 data Stmt phase = Flow (Locator phase) (Locator phase)
-          | FlowTransform (Locator phase) (Transformer phase) (Locator phase)
-          | OnlyWhen (Precondition phase)
-          | Revert
-          | Try [Stmt phase] [Stmt phase]
+                | FlowTransform (Locator phase) (Transformer phase) (Locator phase)
+                | OnlyWhen (Precondition phase)
+                | Revert
+                | Try [Stmt phase] [Stmt phase]
 
 data Decl phase = TypeDecl String [Modifier] (BaseType phase)
-          | TransformerDecl String [VarDef phase] (VarDef phase) [Stmt phase]
+                | TransformerDecl String [VarDef phase] (VarDef phase) [Stmt phase]
 
 data Program phase = Program [Decl phase] [Stmt phase]
 

--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -16,11 +16,32 @@ import Data.Char (toLower)
 import Data.List (intercalate)
 
 -- Compiler phases
+class Phase p where
+    extractBaseType :: XType p -> BaseType p
+    replaceBaseType :: XType p -> BaseType p -> XType p
+
 data Parsed
 data Preprocessed
 data Typechecked
 data Compiled
 
+instance Phase Parsed where
+    extractBaseType (Complete (q, t)) = t
+    extractBaseType (Infer t) = t
+    replaceBaseType (Complete (q, _)) t = Complete (q, t)
+    replaceBaseType (Infer _) t = Infer t
+
+instance Phase Preprocessed where
+    extractBaseType (q, t) = t
+    replaceBaseType (q, _) t = (q, t)
+
+instance Phase Typechecked where
+    extractBaseType (q, t) = t
+    replaceBaseType (q, _) t = (q, t)
+
+instance Phase Compiled where
+    extractBaseType (q, t) = t
+    replaceBaseType (q, _) t = (q, t)
 
 data Modifier = Fungible | Immutable | Consumable | Asset | Unique
     deriving (Show, Eq)

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -477,12 +477,6 @@ isPrimitive PsaString = True
 isPrimitive Address = True
 isPrimitive _ = False
 
-isFungible :: BaseType Typechecked -> State Env Bool
-isFungible Nat = pure True
-isFungible (Named t) = (Fungible `elem`) <$> modifiers t
--- TODO: Update this for later, because tables should be fungible too?
-isFungible _ = pure False
-
 isAsset :: BaseType Typechecked -> State Env Bool
 isAsset (Named t) = do
     decl <- lookupTypeDecl t

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -69,9 +69,7 @@ compileProg (Program decls mainBody) = do
     pure $ Contract "0.7.5" "C" $ allocatorDecls ++ compiledDecls ++ [Constructor [] stmts]
 
 compileDecl :: Decl Compiling -> State (Env Compiling) ()
-compileDecl decl@(TypeDecl name _ baseT) = do
-    modify $ over declarations $ Map.insert name decl
-    defineStruct name baseT
+compileDecl decl@(TypeDecl name _ baseT) = defineStruct name baseT
 
 compileDecl decl@(TransformerDecl name args ret body) = do
     modify $ over declarations $ Map.insert name decl

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -32,6 +33,10 @@ import AST
 import Env
 import Error
 import Phase
+import Transform
+
+instance ProgramTransform Typechecked Typechecked where
+    transformXType x = pure x
 
 freshVar :: State (Env Typechecked) (Locator Typechecked)
 freshVar = Var <$> freshName

--- a/Compiler/src/Compiler.hs
+++ b/Compiler/src/Compiler.hs
@@ -31,6 +31,7 @@ import Debug.Trace
 import AST
 import Env
 import Error
+import Phase
 
 freshVar :: State (Env Typechecked) (Locator Typechecked)
 freshVar = Var <$> freshName

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -12,15 +12,14 @@ import qualified Data.Map as Map
 import AST
 import Error
 
-data Env = Env { _freshCounter       :: Integer,
-                 _typeEnv            :: Map String (BaseType Typechecked),
-                 _declarations       :: Map String (Decl Typechecked),
-                 _solDecls           :: Map String SolDecl,
-                 _allocators         :: Map SolType String,
-                 _preprocessorErrors :: [Error Parsed],
-                 _typecheckerErrors  :: [Error Preprocessed],
-                 _compilerErrors     :: [Error Typechecked] }
-    deriving (Show, Eq)
+data Env phase = Env { _freshCounter       :: Integer,
+                       _typeEnv            :: Map String (BaseType phase),
+                       _declarations       :: Map String (Decl phase),
+                       _solDecls           :: Map String SolDecl,
+                       _allocators         :: Map SolType String,
+                       _preprocessorErrors :: [Error Parsed],
+                       _typecheckerErrors  :: [Error Preprocessed],
+                       _compilerErrors     :: [Error Typechecked] }
 makeLenses ''Env
 
 newEnv = Env { _freshCounter = 0,
@@ -32,21 +31,21 @@ newEnv = Env { _freshCounter = 0,
                _typecheckerErrors = [],
                _compilerErrors = [] }
 
-freshName :: State Env String
+freshName :: State (Env phase) String
 freshName = do
     i <- freshCounter <<+= 1
     pure $ "v" ++ show i
 
-addPreprocessorError :: Error Parsed -> State Env ()
+addPreprocessorError :: Error Parsed -> State (Env Parsed) ()
 addPreprocessorError e = modify $ over preprocessorErrors (e:)
 
-addTypecheckerError :: Error Preprocessed -> State Env ()
+addTypecheckerError :: Error Preprocessed -> State (Env Preprocessed) ()
 addTypecheckerError e = modify $ over typecheckerErrors (e:)
 
-addCompilerError :: Error Typechecked -> State Env ()
+addCompilerError :: Error Typechecked -> State (Env Typechecked) ()
 addCompilerError e = modify $ over compilerErrors (e:)
 
-lookupTypeDecl :: String -> State Env (Decl Typechecked)
+lookupTypeDecl :: String -> State (Env phase) (Decl phase)
 lookupTypeDecl typeName = do
     decl <- Map.lookup typeName . view declarations <$> get
     case decl of
@@ -58,19 +57,19 @@ lookupTypeDecl typeName = do
             pure dummyDecl
         Just tdec@TypeDecl{} -> pure tdec
 
-modifiers :: String -> State Env [Modifier]
+modifiers :: String -> State (Env phase) [Modifier]
 modifiers typeName = do
     decl <- lookupTypeDecl typeName
     case decl of
         TypeDecl _ mods _ -> pure mods
 
-isFungible :: BaseType phase -> State Env Bool
+isFungible :: BaseType phase -> State (Env phase) Bool
 isFungible Nat = pure True
 isFungible (Named t) = (Fungible `elem`) <$> modifiers t
 -- TODO: Update this for later, because tables should be fungible too?
 isFungible _ = pure False
 
-typeOf :: String -> State Env (BaseType Typechecked)
+typeOf :: String -> State (Env phase) (BaseType phase)
 typeOf x = do
     maybeT <- Map.lookup x . view typeEnv <$> get
     case maybeT of
@@ -79,27 +78,27 @@ typeOf x = do
             pure dummyBaseType
         Just t -> pure t
 
-typeOfLoc :: Locator Typechecked -> State Env (BaseType Typechecked)
-typeOfLoc (IntConst _) = pure Nat
-typeOfLoc (BoolConst _) = pure PsaBool
-typeOfLoc (StrConst _) = pure PsaString
-typeOfLoc (AddrConst _) = pure Address
-typeOfLoc (Var x) = typeOf x
-typeOfLoc (Multiset t _) = pure $ Table [] t
-typeOfLoc (Select l k) = do
-    lTy <- typeOfLoc l
-    kTy <- typeOfLoc k
-    keyTypesL <- keyTypes lTy
+typeOfLoc :: Locator Typechecked -> State (Env phase) (BaseType phase)
+-- typeOfLoc (IntConst _) = pure Nat
+-- typeOfLoc (BoolConst _) = pure PsaBool
+-- typeOfLoc (StrConst _) = pure PsaString
+-- typeOfLoc (AddrConst _) = pure Address
+-- typeOfLoc (Var x) = typeOf x
+-- typeOfLoc (Multiset t _) = pure $ Table [] t
+-- typeOfLoc (Select l k) = do
+--     lTy <- typeOfLoc l
+--     kTy <- typeOfLoc k
+--     keyTypesL <- keyTypes lTy
+--     if kTy `elem` keyTypesL then
+--         pure $ valueType lTy
+--     else
+--         pure lTy
 
-    if kTy `elem` keyTypesL then
-        pure $ valueType lTy
-    else
-        pure lTy
 typeOfLoc (Field l x) = do
     lTy <- typeOfLoc l
     lookupField lTy x
 
-lookupField :: BaseType Typechecked -> String -> State Env (BaseType Typechecked)
+lookupField :: BaseType Typechecked -> String -> State (Env phase) (BaseType phase)
 lookupField t@(Record key fields) x =
     case [ t | (VarDef y (_,t)) <- fields, x == y ] of
         [] -> do
@@ -111,7 +110,7 @@ lookupField (Named t) x = do
     case decl of
         TypeDecl _ _ baseT -> lookupField baseT x
 
-keyTypes :: BaseType Typechecked -> State Env [BaseType Typechecked]
+keyTypes :: BaseType Typechecked -> State (Env phase) [BaseType phase]
 keyTypes Nat = pure [Nat]
 keyTypes PsaBool = pure [PsaBool]
 keyTypes PsaString = pure [PsaString]
@@ -136,7 +135,7 @@ valueType (Record keys fields) =
         [ VarDef _ (_,t) ] -> t
         fields -> Record [] fields
 
-demoteBaseType :: BaseType Typechecked -> State Env (BaseType Typechecked)
+demoteBaseType :: BaseType Typechecked -> State (Env Typechecked) (BaseType Typechecked)
 demoteBaseType Nat = pure Nat
 demoteBaseType PsaBool = pure PsaBool
 demoteBaseType PsaString = pure PsaString
@@ -149,6 +148,6 @@ demoteBaseType (Named t) = do
         TypeDecl _ _ baseT -> demoteBaseType baseT
 demoteBaseType Bot = pure Bot
 
-demoteType :: QuantifiedType Typechecked -> State Env (QuantifiedType Typechecked)
+demoteType :: QuantifiedType Typechecked -> State (Env Typechecked) (QuantifiedType Typechecked)
 demoteType (q, t) = (q,) <$> demoteBaseType t
 

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -64,6 +64,12 @@ modifiers typeName = do
     case decl of
         TypeDecl _ mods _ -> pure mods
 
+isFungible :: BaseType phase -> State Env Bool
+isFungible Nat = pure True
+isFungible (Named t) = (Fungible `elem`) <$> modifiers t
+-- TODO: Update this for later, because tables should be fungible too?
+isFungible _ = pure False
+
 typeOf :: String -> State Env (BaseType Typechecked)
 typeOf x = do
     maybeT <- Map.lookup x . view typeEnv <$> get

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -165,14 +165,14 @@ demoteBaseType (Named t) = do
         TypeDecl _ _ baseT -> demoteBaseType baseT
 demoteBaseType Bot = pure Bot
 
-demoteType :: QuantifiedType Typechecked -> State (Env Typechecked) (QuantifiedType Typechecked)
+demoteType :: QuantifiedType Compiling -> State (Env Compiling) (QuantifiedType Compiling)
 demoteType (q, t) = (q,) <$> demoteBaseType t
 
 -- dummy values that are returned as proxies when errors are encountered
 dummyBaseType :: Phase p => BaseType p
 dummyBaseType  = Bot
 
-dummyType :: QuantifiedType Typechecked
+dummyType :: QuantifiedType Compiling
 dummyType = (Any, Bot)
 
 dummyDecl :: forall p. Phase p => Decl p

--- a/Compiler/src/Env.hs
+++ b/Compiler/src/Env.hs
@@ -19,6 +19,7 @@ import qualified Data.Map as Map
 
 import AST
 import Error
+import Phase
 
 data Env phase = Env { _freshCounter :: Integer,
                        _typeEnv      :: Map String (BaseType phase),
@@ -65,7 +66,7 @@ modifiers typeName = do
     case decl of
         TypeDecl _ mods _ -> pure mods
 
-isFungible :: Phase p => BaseType p -> State (Env p) Bool
+isFungible :: (Phase a, Phase b, PhaseTransition a b) => BaseType a -> State (Env b) Bool
 isFungible Nat = pure True
 isFungible (Named t)  = (Fungible `elem`) <$> modifiers t
 -- TODO: Update this for later, because tables should be fungible too?
@@ -121,6 +122,7 @@ keyTypes Address = pure [Address]
 keyTypes (Named t) = do
     demotedT <- demoteBaseType (Named t)
     pure [Named t, demotedT]
+
 keyTypes table@(Table ["key"] t) = do
     let (Record ["key"] [ VarDef "key" keyT, VarDef "value" _ ]) = extractBaseType @p t
     pure [table, extractBaseType keyT]

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -32,13 +32,13 @@ instance Show (XType phase) => PrettyPrint (Error phase) where
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
 -- dummy values that are returned as proxies when errors are encountered
-dummyBaseType :: BaseType Parsed
+dummyBaseType :: BaseType Typechecked
 dummyBaseType = Bot
 
-dummyType :: QuantifiedType Parsed
+dummyType :: QuantifiedType Typechecked
 dummyType = (Any, Bot)
 
-dummyDecl :: Decl Parsed
+dummyDecl :: Decl Typechecked
 dummyDecl = TypeDecl "unknownDecl__" [] dummyBaseType
 
 dummySolExpr :: SolExpr

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -55,14 +55,11 @@ instance Show (XType phase) => PrettyPrint (Error phase) where
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
 groupErrors :: [ErrorCat] -> ([Error Preprocessing], [Error Typechecking], [Error Compiling])
-groupErrors [] = ([], [], [])
-groupErrors (x:xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPreprocessed, groupTypechecked ++ packedTypechecked)
+groupErrors = mconcat . map groupError
     where
-        (packedParsed, packedPreprocessed, packedTypechecked) = case x of
-            (PreprocessorError e) -> ([e], [], [])
-            (TypecheckerError e) -> ([], [e], [])
-            (CompilerError e) -> ([], [], [e])
-        (groupParsed, groupPreprocessed, groupTypechecked) = groupErrors xs
+        groupError (PreprocessorError e) = ([e], [], [])
+        groupError (TypecheckerError e) = ([], [e], [])
+        groupERror (CompilerError e) = ([], [], [e])
 
 indentString :: String -> String
 indentString = unlines . map indent . lines

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -11,17 +11,17 @@ import AST
 import Phase
 
 data Error phase = FlowError String
-                   | SyntaxError String
-                   | UnimplementedError String String
-                   | TypeError String (BaseType phase)
-                   | FieldNotFoundError String (BaseType phase)
-                   | LookupError (LookupErrorCat phase)
+                 | SyntaxError String
+                 | UnimplementedError String String
+                 | TypeError String (BaseType phase)
+                 | FieldNotFoundError String (BaseType phase)
+                 | LookupError (LookupErrorCat phase)
 
 data LookupErrorCat phase = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl (Decl phase)
 
 data ErrorCat = PreprocessorError (Error Preprocessing)
-                | TypecheckerError (Error Typechecking)
-                | CompilerError (Error Compiling)
+              | TypecheckerError (Error Typechecking)
+              | CompilerError (Error Compiling)
     deriving (Eq, Show)
 
 class Errorable e where

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -5,47 +5,69 @@
 
 module Error where
 
+import Data.List
+
 import AST
 import Phase
 
-data Error phase = FlowError String
-           | SyntaxError String
-           | UnimplementedError String String
-           | TypeError String (BaseType phase)
-           | FieldNotFoundError String (BaseType phase)
-           | LookupError (LookupErrorCat phase)
+data Error phase
+  = FlowError String
+  | SyntaxError String
+  | UnimplementedError String String
+  | TypeError String (BaseType phase)
+  | FieldNotFoundError String (BaseType phase)
+  | LookupError (LookupErrorCat phase)
 
 data LookupErrorCat phase = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl (Decl phase)
 
-data ErrorCat = PreprocessorError (Error Parsed)
-              | TypecheckerError (Error Preprocessed)
-              | CompilerError (Error Typechecked)
-    deriving (Eq, Show)
+data ErrorCat
+  = PreprocessorError (Error Parsed)
+  | TypecheckerError (Error Preprocessed)
+  | CompilerError (Error Typechecked)
+  deriving (Eq, Show)
 
 class Errorable e where
-    toErrorCat :: e -> ErrorCat
+  toErrorCat :: e -> ErrorCat
 
 instance Errorable (Error Parsed) where
-    toErrorCat e = PreprocessorError e
+  toErrorCat e = PreprocessorError e
 
 instance Errorable (Error Preprocessed) where
-    toErrorCat e = TypecheckerError e
+  toErrorCat e = TypecheckerError e
 
 instance Errorable (Error Typechecked) where
-    toErrorCat e = CompilerError e
+  toErrorCat e = CompilerError e
 
 deriving instance Eq (XType phase) => Eq (Error phase)
+
 deriving instance Eq (XType phase) => Eq (LookupErrorCat phase)
 
 deriving instance Show (XType phase) => Show (Error phase)
+
 deriving instance Show (XType phase) => Show (LookupErrorCat phase)
 
 instance Show (XType phase) => PrettyPrint (Error phase) where
-    prettyPrint (FlowError s) = ["FlowError: " ++ s]
-    prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
-    prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
-    prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
-    prettyPrint (FieldNotFoundError x t) = ["FieldNotFoundError: Field " ++ x ++ " not found in type " ++ show t]
-    prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
-    prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
-    prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
+  prettyPrint (FlowError s) = ["FlowError: " ++ s]
+  prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
+  prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
+  prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
+  prettyPrint (FieldNotFoundError x t) = ["FieldNotFoundError: Field " ++ x ++ " not found in type " ++ show t]
+  prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
+  prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
+  prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
+
+groupErrors :: [ErrorCat] -> ([Error Parsed], [Error Preprocessed], [Error Typechecked])
+groupErrors (x : xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPreprocessed, groupTypechecked ++ packedTypechecked)
+  where
+    (packedParsed, packedPreprocessed, packedTypechecked) = case x of
+      (PreprocessorError e) -> ([e], [], [])
+      (TypecheckerError e) -> ([], [e], [])
+      (CompilerError e) -> ([], [], [e])
+    (groupParsed, groupPreprocessed, groupTypechecked) = groupErrors xs
+
+instance PrettyPrint [ErrorCat] where
+    prettyPrint errors = [ "Preprocessor errors: \n" ++ intercalate "\n" (map prettyStr preprocessorErrors),
+                           "Typechecker errors: \n" ++ intercalate "\n" (map prettyStr typecheckerErrors),
+                           "Compiler errors: \n" ++ intercalate "\n" (map prettyStr compilerErrors) ]
+        where
+            (preprocessorErrors, typecheckerErrors, compilerErrors) = groupErrors errors

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -64,9 +64,12 @@ groupErrors (x:xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPr
             (CompilerError e) -> ([], [], [e])
         (groupParsed, groupPreprocessed, groupTypechecked) = groupErrors xs
 
+indentString :: String -> String
+indentString = unlines . map indent . lines
+
 instance PrettyPrint [ErrorCat] where
-    prettyPrint errors = [ "Preprocessor errors: \n" ++ intercalate "\n" (map prettyStr preprocessorErrors),
-                           "Typechecker errors: \n" ++ intercalate "\n" (map prettyStr typecheckerErrors),
-                           "Compiler errors: \n" ++ intercalate "\n" (map prettyStr compilerErrors) ]
+    prettyPrint errors = filter (not . null) [ if (not . null) preprocessorErrors then "Preprocessor errors\n" ++ indentString (intercalate "\n" (map prettyStr preprocessorErrors)) else "",
+                                               if (not . null) typecheckerErrors then "Typechecker errors: \n" ++ indentString (intercalate "\n" (map prettyStr typecheckerErrors)) else "",
+                                               if (not .null) compilerErrors then "Compiler errors: \n" ++ indentString (intercalate "\n" (map prettyStr compilerErrors)) else "" ]
         where
             (preprocessorErrors, typecheckerErrors, compilerErrors) = groupErrors errors

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -1,19 +1,27 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Error where
 
 import AST
 
-data Error = FlowError String
+data Error phase = FlowError String
            | SyntaxError String
            | UnimplementedError String String
-           | TypeError String BaseType
-           | FieldNotFoundError String BaseType
-           | LookupError LookupErrorCat
-    deriving (Show, Eq)
+           | TypeError String (BaseType phase)
+           | FieldNotFoundError String (BaseType phase)
+           | LookupError (LookupErrorCat phase)
 
-data LookupErrorCat = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl Decl
-    deriving (Eq, Show)
+data LookupErrorCat phase = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl (Decl phase)
 
-instance PrettyPrint Error where
+deriving instance Eq (XType phase) => Eq (Error phase)
+deriving instance Eq (XType phase) => Eq (LookupErrorCat phase)
+
+deriving instance Show (XType phase) => Show (Error phase)
+deriving instance Show (XType phase) => Show (LookupErrorCat phase)
+
+instance Show (XType phase) => PrettyPrint (Error phase) where
     prettyPrint (FlowError s) = ["FlowError: " ++ s]
     prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
     prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
@@ -24,13 +32,13 @@ instance PrettyPrint Error where
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
 -- dummy values that are returned as proxies when errors are encountered
-dummyBaseType :: BaseType
+dummyBaseType :: BaseType Parsed
 dummyBaseType = Bot
 
-dummyType :: Type
+dummyType :: QuantifiedType Parsed
 dummyType = (Any, Bot)
 
-dummyDecl :: Decl
+dummyDecl :: Decl Parsed
 dummyDecl = TypeDecl "unknownDecl__" [] dummyBaseType
 
 dummySolExpr :: SolExpr

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -19,21 +19,21 @@ data Error phase = FlowError String
 
 data LookupErrorCat phase = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl (Decl phase)
 
-data ErrorCat = PreprocessorError (Error Parsed)
-                | TypecheckerError (Error Preprocessed)
-                | CompilerError (Error Typechecked)
+data ErrorCat = PreprocessorError (Error Preprocessing)
+                | TypecheckerError (Error Typechecking)
+                | CompilerError (Error Compiling)
     deriving (Eq, Show)
 
 class Errorable e where
     toErrorCat :: e -> ErrorCat
 
-instance Errorable (Error Parsed) where
+instance Errorable (Error Preprocessing) where
     toErrorCat e = PreprocessorError e
 
-instance Errorable (Error Preprocessed) where
+instance Errorable (Error Typechecking) where
     toErrorCat e = TypecheckerError e
 
-instance Errorable (Error Typechecked) where
+instance Errorable (Error Compiling) where
     toErrorCat e = CompilerError e
 
 deriving instance Eq (XType phase) => Eq (Error phase)
@@ -54,7 +54,7 @@ instance Show (XType phase) => PrettyPrint (Error phase) where
     prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
-groupErrors :: [ErrorCat] -> ([Error Parsed], [Error Preprocessed], [Error Typechecked])
+groupErrors :: [ErrorCat] -> ([Error Preprocessing], [Error Typechecking], [Error Compiling])
 groupErrors [] = ([], [], [])
 groupErrors (x:xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPreprocessed, groupTypechecked ++ packedTypechecked)
     where

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -59,14 +59,17 @@ groupErrors = mconcat . map groupError
     where
         groupError (PreprocessorError e) = ([e], [], [])
         groupError (TypecheckerError e) = ([], [e], [])
-        groupERror (CompilerError e) = ([], [], [e])
+        groupError (CompilerError e) = ([], [], [e])
 
 indentString :: String -> String
 indentString = unlines . map indent . lines
 
 instance PrettyPrint [ErrorCat] where
-    prettyPrint errors = filter (not . null) [ if (not . null) preprocessorErrors then "Preprocessor errors\n" ++ indentString (intercalate "\n" (map prettyStr preprocessorErrors)) else "",
-                                               if (not . null) typecheckerErrors then "Typechecker errors: \n" ++ indentString (intercalate "\n" (map prettyStr typecheckerErrors)) else "",
-                                               if (not .null) compilerErrors then "Compiler errors: \n" ++ indentString (intercalate "\n" (map prettyStr compilerErrors)) else "" ]
+    prettyPrint errors = concat [
+            printError "Preprocessor errors" preprocessorErrors,
+            printError "Typechecker errors" typecheckerErrors,
+            printError "Compiler errors" compilerErrors
+        ]
         where
             (preprocessorErrors, typecheckerErrors, compilerErrors) = groupErrors errors
+            printError phase errors  = if (not . null) errors then phase : map indent (concatMap prettyPrint errors) else []

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Error where
@@ -50,16 +48,3 @@ instance Show (XType phase) => PrettyPrint (Error phase) where
     prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
     prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
     prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
-
--- dummy values that are returned as proxies when errors are encountered
-dummyBaseType :: Phase p => BaseType p
-dummyBaseType  = Bot
-
-dummyType :: QuantifiedType Typechecked
-dummyType = (Any, Bot)
-
-dummyDecl :: forall p. Phase p => Decl p
-dummyDecl = TypeDecl "unknownDecl__" [] (dummyBaseType @p)
-
-dummySolExpr :: SolExpr
-dummySolExpr = SolVar "unknownExpr__"

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -10,33 +10,31 @@ import Data.List
 import AST
 import Phase
 
-data Error phase
-  = FlowError String
-  | SyntaxError String
-  | UnimplementedError String String
-  | TypeError String (BaseType phase)
-  | FieldNotFoundError String (BaseType phase)
-  | LookupError (LookupErrorCat phase)
+data Error phase = FlowError String
+                   | SyntaxError String
+                   | UnimplementedError String String
+                   | TypeError String (BaseType phase)
+                   | FieldNotFoundError String (BaseType phase)
+                   | LookupError (LookupErrorCat phase)
 
 data LookupErrorCat phase = LookupErrorVar String | LookupErrorType String | LookupErrorTypeDecl (Decl phase)
 
-data ErrorCat
-  = PreprocessorError (Error Parsed)
-  | TypecheckerError (Error Preprocessed)
-  | CompilerError (Error Typechecked)
-  deriving (Eq, Show)
+data ErrorCat = PreprocessorError (Error Parsed)
+                | TypecheckerError (Error Preprocessed)
+                | CompilerError (Error Typechecked)
+    deriving (Eq, Show)
 
 class Errorable e where
-  toErrorCat :: e -> ErrorCat
+    toErrorCat :: e -> ErrorCat
 
 instance Errorable (Error Parsed) where
-  toErrorCat e = PreprocessorError e
+    toErrorCat e = PreprocessorError e
 
 instance Errorable (Error Preprocessed) where
-  toErrorCat e = TypecheckerError e
+    toErrorCat e = TypecheckerError e
 
 instance Errorable (Error Typechecked) where
-  toErrorCat e = CompilerError e
+    toErrorCat e = CompilerError e
 
 deriving instance Eq (XType phase) => Eq (Error phase)
 
@@ -47,23 +45,24 @@ deriving instance Show (XType phase) => Show (Error phase)
 deriving instance Show (XType phase) => Show (LookupErrorCat phase)
 
 instance Show (XType phase) => PrettyPrint (Error phase) where
-  prettyPrint (FlowError s) = ["FlowError: " ++ s]
-  prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
-  prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
-  prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
-  prettyPrint (FieldNotFoundError x t) = ["FieldNotFoundError: Field " ++ x ++ " not found in type " ++ show t]
-  prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
-  prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
-  prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
+    prettyPrint (FlowError s) = ["FlowError: " ++ s]
+    prettyPrint (SyntaxError s) = ["SyntaxError: " ++ s]
+    prettyPrint (UnimplementedError feature target) = ["UnimplementedError: " ++ feature ++ " is not implemented for " ++ target]
+    prettyPrint (TypeError s t) = ["TypeError: " ++ s ++ " type " ++ show t]
+    prettyPrint (FieldNotFoundError x t) = ["FieldNotFoundError: Field " ++ x ++ " not found in type " ++ show t]
+    prettyPrint (LookupError (LookupErrorVar s)) = ["LookupError: Variable " ++ s ++ " is not defined"]
+    prettyPrint (LookupError (LookupErrorType s)) = ["LookupError: Type " ++ s ++ " is not defined"]
+    prettyPrint (LookupError (LookupErrorTypeDecl (TransformerDecl tx _ _ _))) = ["LookupError: expected type but got transformer" ++ show tx]
 
 groupErrors :: [ErrorCat] -> ([Error Parsed], [Error Preprocessed], [Error Typechecked])
-groupErrors (x : xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPreprocessed, groupTypechecked ++ packedTypechecked)
-  where
-    (packedParsed, packedPreprocessed, packedTypechecked) = case x of
-      (PreprocessorError e) -> ([e], [], [])
-      (TypecheckerError e) -> ([], [e], [])
-      (CompilerError e) -> ([], [], [e])
-    (groupParsed, groupPreprocessed, groupTypechecked) = groupErrors xs
+groupErrors [] = ([], [], [])
+groupErrors (x:xs) = (groupParsed ++ packedParsed, groupPreprocessed ++ packedPreprocessed, groupTypechecked ++ packedTypechecked)
+    where
+        (packedParsed, packedPreprocessed, packedTypechecked) = case x of
+            (PreprocessorError e) -> ([e], [], [])
+            (TypecheckerError e) -> ([], [e], [])
+            (CompilerError e) -> ([], [], [e])
+        (groupParsed, groupPreprocessed, groupTypechecked) = groupErrors xs
 
 instance PrettyPrint [ErrorCat] where
     prettyPrint errors = [ "Preprocessor errors: \n" ++ intercalate "\n" (map prettyStr preprocessorErrors),

--- a/Compiler/src/Error.hs
+++ b/Compiler/src/Error.hs
@@ -6,6 +6,7 @@
 module Error where
 
 import AST
+import Phase
 
 data Error phase = FlowError String
            | SyntaxError String

--- a/Compiler/src/Parser.hs
+++ b/Compiler/src/Parser.hs
@@ -9,6 +9,7 @@ import Text.Parsec hiding (Empty)
 import Text.Parsec.Expr
 
 import AST
+import Phase
 
 type Parser a = forall s st m. Stream s m Char => ParsecT s st m a
 

--- a/Compiler/src/Phase.hs
+++ b/Compiler/src/Phase.hs
@@ -4,18 +4,17 @@
 module Phase where
 
 -- Compiler phases
-data Parsed
-data Preprocessed
-data Typechecked
-data Compiled
+data Preprocessing
+data Typechecking
+data Compiling
 
 -- Phase transitions - either moving to next phase or staying in current phase
 class PhaseTransition a b
 
-instance PhaseTransition Parsed Parsed
-instance PhaseTransition Parsed Preprocessed
+instance PhaseTransition Preprocessing Preprocessing
+instance PhaseTransition Preprocessing Typechecking
 
-instance PhaseTransition Preprocessed Preprocessed
-instance PhaseTransition Preprocessed Typechecked
+instance PhaseTransition Typechecking Typechecking
+instance PhaseTransition Typechecking Compiling
 
-instance PhaseTransition Typechecked Typechecked
+instance PhaseTransition Compiling Compiling

--- a/Compiler/src/Phase.hs
+++ b/Compiler/src/Phase.hs
@@ -8,6 +8,10 @@ data Preprocessing
 data Typechecking
 data Compiling
 
+-- A marker type for phases
+data PhaseMarker = Preprocessor | Typechecker | Compiler
+    deriving (Show, Eq)
+
 -- Phase transitions - either moving to next phase or staying in current phase
 class PhaseTransition a b
 

--- a/Compiler/src/Phase.hs
+++ b/Compiler/src/Phase.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Phase where
+
+-- Compiler phases
+data Parsed
+data Preprocessed
+data Typechecked
+data Compiled
+
+-- Phase transitions - either moving to next phase or staying in current phase
+class PhaseTransition a b
+
+instance PhaseTransition Parsed Parsed
+instance PhaseTransition Parsed Preprocessed
+
+instance PhaseTransition Preprocessed Preprocessed
+instance PhaseTransition Preprocessed Typechecked
+
+instance PhaseTransition Typechecked Typechecked

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -148,7 +148,6 @@ expandCond (BinOp OpIn a b) = do
     qt <- transformXType (Infer tyA)
     transformedA <- transformLocator a
     transformedB <- transformLocator b
-    --- TODO: Once we have type quantity inference, we can replace Any here with something more specific. Regardless, this should always be safe.
     pure [ Flow (Select transformedB (Multiset qt [transformedA])) transformedB ]
 
 expandCond (BinOp OpNe a b) = do

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -34,22 +34,36 @@ preprocessDecl :: Decl Parsed-> State Env [Decl Preprocessed]
 preprocessDecl (TransformerDecl name args ret body) = do
     newBody <- concat <$> mapM preprocessStmt body
     modify $ set typeEnv Map.empty
-    pure [TransformerDecl name (map transformVarDef args) (transformVarDef ret) newBody]
-preprocessDecl d = pure [transformDecl d]
+    transformedArgs <- mapM transformVarDef args
+    transformedRet <- transformVarDef ret
+    pure [TransformerDecl name transformedArgs transformedRet newBody]
+
+preprocessDecl d = do
+    transformedDecl <- transformDecl d
+    pure [transformedDecl]
 
 -- TODO: Might need to make this more flexible, in case we need to generate declarations or something
 preprocessStmt :: Stmt Parsed -> State Env [Stmt Preprocessed]
 preprocessStmt (OnlyWhen cond) = preprocessCond cond
 preprocessStmt s@(Flow _ dst) = do
     declareVars dst
-    pure [transformStmt s]
+    transformedStmt <- transformStmt s
+    pure [transformedStmt]
+
 preprocessStmt s@(FlowTransform _ _ dst) = do
     declareVars dst
-    pure [transformStmt s]
-preprocessStmt s = pure [transformStmt s]
+    transformedStmt <- transformStmt s
+    pure [transformedStmt]
+
+preprocessStmt s = do
+    transformedStmt <- transformStmt s
+    pure [transformedStmt]
 
 declareVars :: Locator Parsed -> State Env ()
-declareVars (NewVar x t) = modify $ over typeEnv $ Map.insert x (transformBaseType t)
+declareVars (NewVar x baseT) = do
+    transformedBaseT <- transformBaseType baseT
+    modify $ over typeEnv $ Map.insert x transformedBaseT
+
 declareVars _ = pure ()
 
 preprocessCond :: Precondition Parsed -> State Env [Stmt Preprocessed]
@@ -60,7 +74,11 @@ preprocessCond (Disj (c1:cs)) = do
     checkC1 <- preprocessCond c1
     checkCs <- preprocessCond $ Disj cs
     pure [ Try checkC1 checkCs ]
-preprocessCond (NegateCond cond) = preprocessCond $ transformPrecondition (expandNegate cond)
+
+preprocessCond (NegateCond cond) = do
+    expandedCond <- expandNegate cond
+    preprocessCond expandedCond
+
 preprocessCond (BinOp op a b) = do
     (allocA, newA) <- allocateVar a
     newAllocA <- concat <$> mapM preprocessStmt allocA
@@ -69,29 +87,38 @@ preprocessCond (BinOp op a b) = do
     res <- expandCond $ BinOp op newA newB
     pure $ newAllocA ++ newAllocB ++ res
 
-expandNegate :: Precondition Parsed -> Precondition Preprocessed
-expandNegate (BinOp OpEq a b) = transformPrecondition (BinOp OpNe a b)
-expandNegate (BinOp OpNe a b) = transformPrecondition (BinOp OpEq a b)
-expandNegate (BinOp OpLt a b) = transformPrecondition (BinOp OpGe a b)
-expandNegate (BinOp OpGt a b) = transformPrecondition (BinOp OpLe a b)
-expandNegate (BinOp OpLe a b) = transformPrecondition (BinOp OpGt a b)
-expandNegate (BinOp OpGe a b) = transformPrecondition (BinOp OpLt a b)
-expandNegate (BinOp OpIn a b) = transformPrecondition (BinOp OpNotIn a b)
-expandNegate (BinOp OpNotIn a b) = transformPrecondition (BinOp OpIn a b)
-expandNegate (Conj conds) = Disj $ map expandNegate conds
-expandNegate (Disj conds) = Conj $ map expandNegate conds
+expandNegate :: Precondition Parsed -> State Env (Precondition Parsed)
+expandNegate (BinOp OpEq a b) = pure (BinOp OpNe a b)
+expandNegate (BinOp OpNe a b) = pure (BinOp OpEq a b)
+expandNegate (BinOp OpLt a b) = pure (BinOp OpGe a b)
+expandNegate (BinOp OpGt a b) = pure (BinOp OpLe a b)
+expandNegate (BinOp OpLe a b) = pure (BinOp OpGt a b)
+expandNegate (BinOp OpGe a b) = pure (BinOp OpLt a b)
+expandNegate (BinOp OpIn a b) = pure (BinOp OpNotIn a b)
+expandNegate (BinOp OpNotIn a b) = pure (BinOp OpIn a b)
+expandNegate (Conj conds) = do
+    expandedConds <- mapM expandNegate conds
+    pure $ Disj expandedConds
+
+expandNegate (Disj conds) = do
+    expandedConds <- mapM expandNegate conds
+    pure $ Conj expandedConds
+
 expandNegate (NegateCond cond) = transformPrecondition cond
 
 allocateVar :: Locator Parsed -> State Env ([Stmt Parsed], Locator Parsed)
 allocateVar (IntConst n) = do
     x <- freshName
     pure ([ Flow (IntConst n) (NewVar x Nat) ], Var x)
+
 allocateVar (BoolConst b) = do
     x <- freshName
     pure ([ Flow (BoolConst b) (NewVar x PsaBool) ], Var x)
+
 allocateVar l@(Multiset elemT elems) = do
     x <- freshName
     pure ([ Flow l (NewVar x (Table [] elemT))], Var x)
+
 allocateVar l = pure ([], l)
 
 expandCond :: Precondition Parsed -> State Env [Stmt Preprocessed]
@@ -105,21 +132,34 @@ expandCond :: Precondition Parsed -> State Env [Stmt Preprocessed]
 expandCond cond@(BinOp OpLt a b) = do
     addPreprocessorError $ UnimplementedError "only when" $ show cond
     pure []
+
 expandCond cond@(BinOp OpGt a b) = do
     addPreprocessorError $ UnimplementedError "only when" $ show cond
     pure []
-expandCond (BinOp OpEq a b) = pure [
-                                Flow (Select (transformLocator a) (transformLocator b)) (transformLocator a),
-                                Flow (Select (transformLocator b) (transformLocator a)) (transformLocator b)
-                            ]
+
+expandCond (BinOp OpEq a b) = do
+    transformedA <- transformLocator a
+    transformedB <- transformLocator b
+    pure [ Flow (Select transformedA transformedB) transformedA,
+           Flow (Select transformedB transformedA) transformedB ]
+
 expandCond (BinOp OpIn a b) = do
     tyA <- typeOfLoc a
+    qt <- transformXType (Infer tyA)
+    transformedA <- transformLocator a
+    transformedB <- transformLocator b
     --- TODO: Once we have type quantity inference, we can replace Any here with something more specific. Regardless, this should always be safe.
-    pure [ Flow (Select (transformLocator b) (Multiset (Any, tyA) [transformLocator a])) (transformLocator b) ]
+    pure [ Flow (Select transformedB (Multiset qt [transformedA])) transformedB ]
+
 expandCond (BinOp OpNe a b) = do
     failure <- expandCond (BinOp OpEq a b)
     pure [Try (failure ++ [ Revert ]) []]
-expandCond (BinOp OpLe a b) = pure [ Flow (Select (transformLocator b) (transformLocator a)) (transformLocator b) ]
+
+expandCond (BinOp OpLe a b) = do
+    transformedA <- transformLocator a
+    transformedB <- transformLocator b
+    pure [ Flow (Select transformedB transformedA) transformedB ]
+    
 expandCond (BinOp OpGe a b) = expandCond (BinOp OpLt b a)
 expandCond (BinOp OpNotIn a b) = do
     failure <- expandCond (BinOp OpIn a b)

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Preprocessor where
 
 import Control.Lens (over, set)
@@ -9,37 +12,41 @@ import AST
 import Env
 import Error
 
--- TODO: Probably want to have multiple AST types for better type safety
-preprocess :: Program -> State Env Program
+instance ProgramTransform Parsed Preprocessed where
+    transformXType (Complete qt) = transformQuantifiedType qt
+ -- TODO: Proper type quantity inference (placeholder for now)
+    transformXType (Infer baseT) = (Any, transformBaseType baseT)
+
+preprocess :: Program Parsed -> State Env (Program Preprocessed)
 preprocess (Program decls stmts) = do
     newProg <- Program <$> (concat <$> mapM preprocessDecl decls)
                        <*> (concat <$> mapM preprocessStmt stmts)
     modify $ set typeEnv Map.empty
     pure newProg
 
-preprocessDecl :: Decl -> State Env [Decl]
+preprocessDecl :: Decl Parsed-> State Env [Decl Preprocessed]
 preprocessDecl (TransformerDecl name args ret body) = do
     newBody <- concat <$> mapM preprocessStmt body
     modify $ set typeEnv Map.empty
-    pure [TransformerDecl name args ret newBody]
-preprocessDecl d = pure [d]
+    pure [TransformerDecl name (map transformVarDef args) (transformVarDef ret) newBody]
+preprocessDecl d = pure [transformDecl d]
 
 -- TODO: Might need to make this more flexible, in case we need to generate declarations or something
-preprocessStmt :: Stmt -> State Env [Stmt]
+preprocessStmt :: Stmt Parsed -> State Env [Stmt Preprocessed]
 preprocessStmt (OnlyWhen cond) = preprocessCond cond
 preprocessStmt s@(Flow _ dst) = do
     declareVars dst
-    pure [s]
+    pure [transformStmt s]
 preprocessStmt s@(FlowTransform _ _ dst) = do
     declareVars dst
-    pure [s]
-preprocessStmt s = pure [s]
+    pure [transformStmt s]
+preprocessStmt s = pure [transformStmt s]
 
-declareVars :: Locator -> State Env ()
-declareVars (NewVar x t) = modify $ over typeEnv $ Map.insert x t
+declareVars :: Locator Parsed -> State Env ()
+declareVars (NewVar x t) = modify $ over typeEnv $ Map.insert x (transformBaseType t)
 declareVars _ = pure ()
 
-preprocessCond :: Precondition -> State Env [Stmt]
+preprocessCond :: Precondition Parsed -> State Env [Stmt Preprocessed]
 preprocessCond (Conj conds) = concat <$> mapM preprocessCond conds
 preprocessCond (Disj []) = pure []
 preprocessCond (Disj [cond]) = preprocessCond cond
@@ -47,7 +54,7 @@ preprocessCond (Disj (c1:cs)) = do
     checkC1 <- preprocessCond c1
     checkCs <- preprocessCond $ Disj cs
     pure [ Try checkC1 checkCs ]
-preprocessCond (NegateCond cond) = preprocessCond $ expandNegate cond
+preprocessCond (NegateCond cond) = preprocessCond $ transformPrecondition (expandNegate cond)
 preprocessCond (BinOp op a b) = do
     (allocA, newA) <- allocateVar a
     newAllocA <- concat <$> mapM preprocessStmt allocA
@@ -56,20 +63,20 @@ preprocessCond (BinOp op a b) = do
     res <- expandCond $ BinOp op newA newB
     pure $ newAllocA ++ newAllocB ++ res
 
-expandNegate :: Precondition -> Precondition
-expandNegate (BinOp OpEq a b) = BinOp OpNe a b
-expandNegate (BinOp OpNe a b) = BinOp OpEq a b
-expandNegate (BinOp OpLt a b) = BinOp OpGe a b
-expandNegate (BinOp OpGt a b) = BinOp OpLe a b
-expandNegate (BinOp OpLe a b) = BinOp OpGt a b
-expandNegate (BinOp OpGe a b) = BinOp OpLt a b
-expandNegate (BinOp OpIn a b) = BinOp OpNotIn a b
-expandNegate (BinOp OpNotIn a b) = BinOp OpIn a b
+expandNegate :: Precondition Parsed -> Precondition Preprocessed
+expandNegate (BinOp OpEq a b) = transformPrecondition (BinOp OpNe a b)
+expandNegate (BinOp OpNe a b) = transformPrecondition (BinOp OpEq a b)
+expandNegate (BinOp OpLt a b) = transformPrecondition (BinOp OpGe a b)
+expandNegate (BinOp OpGt a b) = transformPrecondition (BinOp OpLe a b)
+expandNegate (BinOp OpLe a b) = transformPrecondition (BinOp OpGt a b)
+expandNegate (BinOp OpGe a b) = transformPrecondition (BinOp OpLt a b)
+expandNegate (BinOp OpIn a b) = transformPrecondition (BinOp OpNotIn a b)
+expandNegate (BinOp OpNotIn a b) = transformPrecondition (BinOp OpIn a b)
 expandNegate (Conj conds) = Disj $ map expandNegate conds
 expandNegate (Disj conds) = Conj $ map expandNegate conds
-expandNegate (NegateCond cond) = cond
+expandNegate (NegateCond cond) = transformPrecondition cond
 
-allocateVar :: Locator -> State Env ([Stmt], Locator)
+allocateVar :: Locator Parsed -> State Env ([Stmt Parsed], Locator Parsed)
 allocateVar (IntConst n) = do
     x <- freshName
     pure ([ Flow (IntConst n) (NewVar x Nat) ], Var x)
@@ -81,7 +88,7 @@ allocateVar l@(Multiset elemT elems) = do
     pure ([ Flow l (NewVar x (Table [] elemT))], Var x)
 allocateVar l = pure ([], l)
 
-expandCond :: Precondition -> State Env [Stmt]
+expandCond :: Precondition Parsed -> State Env [Stmt Preprocessed]
 -- TODO: We need to be able to write things like "x + 1" in locators for this to work out nicely (alternatively, we could compile things like:
 -- only when a <= b
 -- into
@@ -90,20 +97,23 @@ expandCond :: Precondition -> State Env [Stmt]
 -- temp --> b
 -- But that's kind of annoying, and requires type information)
 expandCond cond@(BinOp OpLt a b) = do
-    addError $ UnimplementedError "only when" $ show cond
+    addPreprocessorError $ UnimplementedError "only when" $ show cond
     pure []
 expandCond cond@(BinOp OpGt a b) = do
-    addError $ UnimplementedError "only when" $ show cond
+    addPreprocessorError $ UnimplementedError "only when" $ show cond
     pure []
-expandCond (BinOp OpEq a b) = pure [ Flow (Select a b) a, Flow (Select b a) b ]
+expandCond (BinOp OpEq a b) = pure [
+                                Flow (Select (transformLocator a) (transformLocator b)) (transformLocator a),
+                                Flow (Select (transformLocator b) (transformLocator a)) (transformLocator b)
+                            ]
 expandCond (BinOp OpIn a b) = do
     tyA <- typeOfLoc a
     --- TODO: Once we have type quantity inference, we can replace Any here with something more specific. Regardless, this should always be safe.
-    pure [ Flow (Select b (Multiset (Any, tyA) [a])) b ]
+    pure [ Flow (Select (transformLocator b) (Multiset (Any, tyA) [transformLocator a])) (transformLocator b) ]
 expandCond (BinOp OpNe a b) = do
     failure <- expandCond (BinOp OpEq a b)
     pure [Try (failure ++ [ Revert ]) []]
-expandCond (BinOp OpLe a b) = pure [ Flow (Select b a) b ]
+expandCond (BinOp OpLe a b) = pure [ Flow (Select (transformLocator b) (transformLocator a)) (transformLocator b) ]
 expandCond (BinOp OpGe a b) = expandCond (BinOp OpLt b a)
 expandCond (BinOp OpNotIn a b) = do
     failure <- expandCond (BinOp OpIn a b)

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -104,13 +104,9 @@ expandNegate (BinOp OpLe a b) = pure (BinOp OpGt a b)
 expandNegate (BinOp OpGe a b) = pure (BinOp OpLt a b)
 expandNegate (BinOp OpIn a b) = pure (BinOp OpNotIn a b)
 expandNegate (BinOp OpNotIn a b) = pure (BinOp OpIn a b)
-expandNegate (Conj conds) = do
-    expandedConds <- mapM expandNegate conds
-    pure $ Disj expandedConds
+expandNegate (Conj conds) = Disj <$> mapM expandNegate conds
 
-expandNegate (Disj conds) = do
-    expandedConds <- mapM expandNegate conds
-    pure $ Conj expandedConds
+expandNegate (Disj conds) = Conj <$> mapM expandNegate conds
 
 expandNegate (NegateCond cond) = pure cond
 

--- a/Compiler/src/Preprocessor.hs
+++ b/Compiler/src/Preprocessor.hs
@@ -11,11 +11,17 @@ import qualified Data.Map as Map
 import AST
 import Env
 import Error
+import Transform
 
 instance ProgramTransform Parsed Preprocessed where
     transformXType (Complete qt) = transformQuantifiedType qt
- -- TODO: Proper type quantity inference (placeholder for now)
-    transformXType (Infer baseT) = (Any, transformBaseType baseT)
+    transformXType (Infer baseT) = do
+        transformedBaseT <- transformBaseType baseT
+        tIsFungible <- isFungible transformedBaseT
+        if tIsFungible then
+            pure (Any, transformedBaseT)
+        else
+            pure (One, transformedBaseT)
 
 preprocess :: Program Parsed -> State Env (Program Preprocessed)
 preprocess (Program decls stmts) = do

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -16,6 +16,10 @@ import AST
 import Env
 import Phase
 
+-- | Applies functions accross to (result, Env) pairs across phases
+(>>>) :: (ProgramTransform p1 p2, PhaseTransition p1 p1) => (a, Env p1) -> (a -> State (Env p2) b) -> (b, Env p2)
+(a, s) >>> f = runState (f a) (transformEnv s)
+
 -- AST transforms
 class (Phase a, Phase b) => ProgramTransform a b where
     transformXType :: (Phase c, PhaseTransition a c) => XType a -> State (Env c) (XType b)

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -64,6 +64,14 @@ transformLocator (NewVar name baseT) = do
     transformedBaseT <- transformBaseType baseT
     pure $ NewVar name transformedBaseT
 
+transformLocator Consume = pure Consume
+
+transformLocator (RecordLit keys members) = do
+    let (varDefs, locators) = unzip members
+    transformedVarDefs <- mapM transformVarDef varDefs
+    transformedLocators <- mapM transformLocator locators
+    pure $ RecordLit keys (zip transformedVarDefs transformedLocators)
+
 transformLocator (Filter l q predName args) = do
     transformedL <- transformLocator l
     transformedArgs <- mapM transformLocator args

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -103,4 +103,9 @@ transformEnv env = let (transformedTypeEnvs, s) = runState (mapM transformBaseTy
                             _declarations = transformedDecls,
                             _solDecls = env^.solDecls,
                             _allocators = env^.allocators,
-                            _errors = env^.errors }
+                            _errors = env^.errors,
+                            _phaseMarker = promotePhase $ env^.phaseMarker }
+    where
+        promotePhase Preprocessor = Typechecker
+        promotePhase Typechecker  = Compiler
+        promotePhase Compiler     = Compiler

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -135,6 +135,7 @@ transformDecl (TransformerDecl name args ret body) = do
     transformedBody <- mapM transformStmt body
     pure $ TransformerDecl name transformedArgs transformedRet transformedBody
 
+transformEnv :: forall a b. (Phase a, Phase b, ProgramTransform a b, PhaseTransition a a) => Env a -> Env b
 transformEnv env = let (transformedTypeEnvs, s) = runState (mapM transformBaseType (view typeEnv env)) env
                        (transformedDecls, _) = runState (mapM transformDecl (view declarations env)) env
                    in Env { _freshCounter = env ^. freshCounter,

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -52,6 +52,7 @@ transformVarDef (VarDef name t) = do
 
 transformLocator :: forall a b c. (Phase a, Phase b, Phase c, ProgramTransform a b, PhaseTransition a c) => Locator a -> State (Env c) (Locator b)
 transformLocator (IntConst i) = pure $ IntConst i
+transformLocator (BoolConst b) = pure $ BoolConst b
 transformLocator (StrConst s) = pure $ StrConst s
 transformLocator (AddrConst addr) = pure $ AddrConst addr
 transformLocator (Var var) = pure $ Var var

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -96,11 +96,11 @@ transformDecl (TypeDecl s modifiers baseT) = TypeDecl s modifiers <$> transformB
 transformDecl (TransformerDecl name args ret body) = TransformerDecl name <$> mapM transformVarDef args <*> transformVarDef ret <*> mapM transformStmt body
 
 transformEnv :: forall a b. (Phase a, Phase b, ProgramTransform a b, PhaseTransition a a) => Env a -> Env b
-transformEnv env = let (transformedTypeEnvs, s) = runState (mapM transformBaseType (view typeEnv env)) env
-                       (transformedDecls, _) = runState (mapM transformDecl (view declarations env)) env
-                   in Env { _freshCounter = env ^. freshCounter,
+transformEnv env = let (transformedTypeEnvs, s) = runState (mapM transformBaseType $ env^.typeEnv) env
+                       (transformedDecls, _) = runState (mapM transformDecl $ env^.declarations) env
+                   in Env { _freshCounter = env^.freshCounter,
                             _typeEnv = transformedTypeEnvs,
                             _declarations = transformedDecls,
-                            _solDecls = env ^. solDecls,
-                            _allocators = env ^. allocators,
-                            _errors = env ^. errors }
+                            _solDecls = env^.solDecls,
+                            _allocators = env^.allocators,
+                            _errors = env^.errors }

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Transform where
+
+import Control.Monad.State
+
+import AST
+import Env
+
+-- AST transforms
+class ProgramTransform a b where
+    transformXType :: XType a -> State Env (XType b)
+
+transformBaseType :: forall a b. ProgramTransform a b => BaseType a -> State Env (BaseType b)
+transformBaseType Nat = pure Nat
+transformBaseType PsaBool = pure PsaBool
+transformBaseType PsaString = pure PsaString
+transformBaseType Address = pure Address
+transformBaseType (Named name) = pure $ Named name
+transformBaseType Bot = pure Bot
+
+transformBaseType (Record keys fields) = do
+    transformedFields <- mapM transformVarDef fields
+    pure $ Record keys transformedFields
+
+transformBaseType (Table keys t) = do
+    transformedT <- transformXType @a @b t
+    pure $ Table keys transformedT
+
+transformQuantifiedType :: forall a b. ProgramTransform a b => QuantifiedType a -> State Env (QuantifiedType b)
+transformQuantifiedType (q, t) = do
+    transformedT <- transformBaseType t
+    pure (q, transformedT)
+
+transformVarDef :: forall a b. ProgramTransform a b => VarDef a -> State Env (VarDef b)
+transformVarDef (VarDef name t) = do
+    transformedT <- transformXType @a @b t
+    pure $ VarDef name transformedT
+
+transformLocator :: forall a b. ProgramTransform a b => Locator a -> State Env (Locator b)
+transformLocator (IntConst i) = pure $ IntConst i
+transformLocator (StrConst s) = pure $ StrConst s
+transformLocator (AddrConst addr) = pure $ AddrConst addr
+transformLocator (Var var) = pure $ Var var
+transformLocator (Field l name) = do
+    transformedL <- transformLocator l
+    pure $ Field transformedL name
+
+transformLocator (Multiset t locators) = do
+    transformedT <- transformXType @a @b t
+    transformedLocators <- mapM transformLocator locators
+
+    pure $ Multiset transformedT transformedLocators
+transformLocator (NewVar name baseT) = do
+    transformedBaseT <- transformBaseType baseT
+    pure $ NewVar name transformedBaseT
+
+transformLocator (Filter l q predName args) = do
+    transformedL <- transformLocator l
+    transformedArgs <- mapM transformLocator args
+    pure $ Filter transformedL q predName transformedArgs
+
+transformLocator (Select l k) = do
+    transformedL <- transformLocator l
+    transformedK <- transformLocator k
+    pure $ Select transformedL transformedK
+
+transformTransformer :: ProgramTransform a b => Transformer a -> State Env (Transformer b)
+transformTransformer (Construct name args) = do
+    transformedArgs <- mapM transformLocator args
+    pure $ Construct name transformedArgs
+
+transformTransformer (Call name args) = do
+    transformedArgs <- mapM transformLocator args
+    pure $ Call name transformedArgs
+
+transformPrecondition :: ProgramTransform a b => Precondition a -> State Env (Precondition b)
+transformPrecondition (Conj conds) = do
+    transformedConds <- mapM transformPrecondition conds
+    pure $ Conj transformedConds
+
+transformPrecondition (Disj conds) = do
+    transformedConds <- mapM transformPrecondition conds
+    pure $ Disj transformedConds
+
+transformPrecondition (BinOp op a b) = do
+    transformedA <- transformLocator a
+    transformedB <- transformLocator b
+    pure $ BinOp op transformedA transformedB
+
+transformPrecondition (NegateCond cond) = do
+    transformedCond <- transformPrecondition cond
+    pure $ NegateCond transformedCond
+
+transformStmt :: ProgramTransform a b => Stmt a -> State Env (Stmt b)
+transformStmt (Flow src dst) = do
+    transformedSrc <- transformLocator src
+    transformedDst <- transformLocator dst
+    pure $ Flow transformedSrc transformedDst
+
+transformStmt (FlowTransform src transformer dst) = do
+    transformedSrc <- transformLocator src
+    transformedDst <- transformLocator dst
+    transformedTransformer <- transformTransformer transformer
+    pure $ FlowTransform transformedSrc transformedTransformer transformedDst
+
+transformStmt (OnlyWhen precondition) = do
+    transformedPrecondition <- transformPrecondition precondition
+    pure $ OnlyWhen transformedPrecondition
+
+transformStmt (Try checkC1 checkCs) = do
+    transformedC1 <- mapM transformStmt checkC1
+    transformedCs <- mapM transformStmt checkCs
+    pure $ Try transformedC1 transformedCs
+
+transformStmt Revert = pure Revert
+
+transformDecl :: ProgramTransform a b => Decl a -> State Env (Decl b)
+transformDecl (TypeDecl s modifiers baseT) = do
+    transformedBaseT <- transformBaseType baseT
+    pure $ TypeDecl s modifiers transformedBaseT
+
+transformDecl (TransformerDecl name args ret body) = do
+    transformedArgs <- mapM transformVarDef args
+    transformedRet <- transformVarDef ret
+    transformedBody <- mapM transformStmt body
+    pure $ TransformerDecl name transformedArgs transformedRet transformedBody

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -24,7 +24,4 @@ checkDecl :: Decl Preprocessed -> State (Env Typechecked) (Decl Typechecked)
 checkDecl = transformDecl
 
 checkStmt :: Stmt Preprocessed -> State (Env Typechecked) (Stmt Typechecked)
-checkStmt (Flow src dst) = do
-    transformedSource <- transformLocator src
-    transformedDest <- transformLocator dst
-    pure $ Flow transformedSource transformedDest
+checkStmt = transformStmt

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -8,6 +8,7 @@ import Control.Monad.State
 
 import AST
 import Env
+import Transform
 
 instance ProgramTransform Preprocessed Typechecked where
     transformXType = transformQuantifiedType
@@ -19,7 +20,10 @@ typecheck prog@(Program decls stmts) = do
     pure $ Program checkedDecls checkedStmts
 
 checkDecl :: Decl Preprocessed -> State Env (Decl Typechecked)
-checkDecl decl = pure $ transformDecl decl
+checkDecl = transformDecl
 
 checkStmt :: Stmt Preprocessed -> State Env (Stmt Typechecked)
-checkStmt (Flow src dst) = pure $ Flow (transformLocator src) (transformLocator dst)
+checkStmt (Flow src dst) = do
+    transformedSource <- transformLocator src
+    transformedDest <- transformLocator dst
+    pure $ Flow transformedSource transformedDest

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -8,6 +8,7 @@ import Control.Monad.State
 
 import AST
 import Env
+import Phase
 import Transform
 
 instance ProgramTransform Preprocessed Typechecked where

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -11,17 +11,17 @@ import Env
 import Phase
 import Transform
 
-instance ProgramTransform Preprocessed Typechecked where
+instance ProgramTransform Typechecking Compiling where
     transformXType = transformQuantifiedType
 
-typecheck :: Program Preprocessed -> State (Env Typechecked) (Program Typechecked)
+typecheck :: Program Typechecking -> State (Env Compiling) (Program Compiling)
 typecheck prog@(Program decls stmts) = do
     checkedDecls <- mapM checkDecl decls
     checkedStmts <- mapM checkStmt stmts
     pure $ Program checkedDecls checkedStmts
 
-checkDecl :: Decl Preprocessed -> State (Env Typechecked) (Decl Typechecked)
+checkDecl :: Decl Typechecking -> State (Env Compiling) (Decl Compiling)
 checkDecl = transformDecl
 
-checkStmt :: Stmt Preprocessed -> State (Env Typechecked) (Stmt Typechecked)
+checkStmt :: Stmt Typechecking -> State (Env Compiling) (Stmt Compiling)
 checkStmt = transformStmt

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -13,16 +13,16 @@ import Transform
 instance ProgramTransform Preprocessed Typechecked where
     transformXType = transformQuantifiedType
 
-typecheck :: Program Preprocessed -> State (Env Preprocessed) (Program Typechecked)
+typecheck :: Program Preprocessed -> State (Env Typechecked) (Program Typechecked)
 typecheck prog@(Program decls stmts) = do
     checkedDecls <- mapM checkDecl decls
     checkedStmts <- mapM checkStmt stmts
     pure $ Program checkedDecls checkedStmts
 
-checkDecl :: Decl Preprocessed -> State (Env Preprocessed) (Decl Typechecked)
+checkDecl :: Decl Preprocessed -> State (Env Typechecked) (Decl Typechecked)
 checkDecl = transformDecl
 
-checkStmt :: Stmt Preprocessed -> State (Env Preprocessed) (Stmt Typechecked)
+checkStmt :: Stmt Preprocessed -> State (Env Typechecked) (Stmt Typechecked)
 checkStmt (Flow src dst) = do
     transformedSource <- transformLocator src
     transformedDest <- transformLocator dst

--- a/Compiler/src/Typechecker.hs
+++ b/Compiler/src/Typechecker.hs
@@ -13,16 +13,16 @@ import Transform
 instance ProgramTransform Preprocessed Typechecked where
     transformXType = transformQuantifiedType
 
-typecheck :: Program Preprocessed -> State Env (Program Typechecked)
+typecheck :: Program Preprocessed -> State (Env Preprocessed) (Program Typechecked)
 typecheck prog@(Program decls stmts) = do
     checkedDecls <- mapM checkDecl decls
     checkedStmts <- mapM checkStmt stmts
     pure $ Program checkedDecls checkedStmts
 
-checkDecl :: Decl Preprocessed -> State Env (Decl Typechecked)
+checkDecl :: Decl Preprocessed -> State (Env Preprocessed) (Decl Typechecked)
 checkDecl = transformDecl
 
-checkStmt :: Stmt Preprocessed -> State Env (Stmt Typechecked)
+checkStmt :: Stmt Preprocessed -> State (Env Preprocessed) (Stmt Typechecked)
 checkStmt (Flow src dst) = do
     transformedSource <- transformLocator src
     transformedDest <- transformLocator dst

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -108,6 +108,12 @@ preprocessorTests = do
             inferred <- evalStr "[ address ; ] --> var m : map address => address"
             complete `shouldBe` inferred
 
+        it "infers user defined fungible types as any" $ do
+            let defineType = "type Token is fungible asset nat"
+            complete <- evalStr $ unlines [defineType, "[ Token ; ] --> var tokens : list Token"]
+            inferred <- evalStr $ unlines [defineType, "[ any Token ; ] --> var tokens : list any Token"]
+            complete `shouldBe` inferred
+
 parserTests = do
     describe "parseStmt" $ do
         it "parses simple flows" $ do

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -47,7 +47,7 @@ evalStr prog = do
     (Program _ progStmts) <- evalEnv newEnv (preprocess parsed)
     pure progStmts
 
-shouldPreprocessAs :: State (Env Preprocessed) [Stmt Preprocessed] -> String -> IO ()
+shouldPreprocessAs :: State (Env Typechecking) [Stmt Typechecking] -> String -> IO ()
 x `shouldPreprocessAs` prog = do
     stmts <- evalEnv newEnv x
     progStmts <- evalStr prog

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -107,7 +107,9 @@ parserTests = do
             parse parseStmt "" "x --> y"
                 `shouldBe` Right (Flow (Var "x") (Var "y"))
             parse parseStmt "" "[ any nat ; ] --> var m : map any nat => any nat"
-                `shouldBe` Right (Flow (Multiset (Any,Nat) []) (NewVar "m" (Table ["key"] (One,Record ["key"] [("key",(Any,Nat)),("value",(Any,Nat))]))))
+                `shouldBe` Right (Flow (Multiset (Complete (Any, Nat)) []) (
+                    NewVar "m" (Table ["key"] (Complete (One, Record ["key"] [VarDef "key" (Complete (Any, Nat)), VarDef "value" (Complete (Any, Nat))])))))
+
         it "parses simple backwards flows" $
             parse parseStmt "" "y <-- 1"
                 `shouldBe` Right (Flow (IntConst 1) (Var "y"))
@@ -115,9 +117,10 @@ parserTests = do
         it "parses transformer flows" $
             parse parseStmt "" "x --> f() --> var t : nat"
                 `shouldBe` Right (FlowTransform (Var "x") (Call "f" []) (NewVar "t" Nat))
+
         it "parses backwards transformer flows" $
             parse parseStmt "" "var ts : multiset any nat <-- g(y) <-- [ any nat; ]"
-                `shouldBe` Right (FlowTransform (NewVar "ts" (Table [] (Any,Nat))) (Call "g" [Var "y"]) (Multiset (Any,Nat) []))
+                `shouldBe` Right (FlowTransform (NewVar "ts" (Table [] (Complete (Any, Nat)))) (Call "g" [Var "y"]) (Multiset (Complete (Any, Nat)) []))
 
         it "parses try-catch statements" $
             parse parseStmt "" "try {} catch {}"
@@ -126,13 +129,15 @@ parserTests = do
         it "parses flows with selector arrow" $
             parse parseStmt "" "x --[ 5 ]-> y"
                 `shouldBe` Right (Flow (Select (Var "x") (IntConst 5)) (Var "y"))
+
         it "parses backwards flows with selector arrow" $
             parse parseStmt "" "var t : bool <-[ z ]-- [ any bool; true, false] "
-                `shouldBe` Right (Flow (Select (Multiset (Any,PsaBool) [BoolConst True,BoolConst False]) (Var "z")) (NewVar "t" PsaBool))
+                `shouldBe` Right (Flow (Select (Multiset (Complete (Any, PsaBool)) [BoolConst True, BoolConst False]) (Var "z")) (NewVar "t" PsaBool))
 
         it "parses flows with filters" $ do
             parse parseStmt "" "A --[ nonempty such that isWinner(winNum) ]-> var winners : mutliset one Ticket"
                 `shouldBe` Right (Flow (Filter (Var "A") Nonempty "isWinner" [Var "winNum"]) (NewVar "winners" (Named "mutliset")))
+
         it "parses backwards flows with filters" $ do
             parse parseStmt "" "vals <-[ any such that nonzero() ]-- src"
                 `shouldBe` Right (Flow (Filter (Var "src") Any "nonzero" []) (Var "vals"))

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -44,12 +44,12 @@ evalEnv env toEval = do
 
 evalStr prog = do
     parsed <- parseAndCheck parseProgram prog
-    (Program _ progStmts) <- evalEnv newEnv (preprocess parsed)
+    (Program _ progStmts) <- evalEnv (newEnv Preprocessor) (preprocess parsed)
     pure progStmts
 
 shouldPreprocessAs :: State (Env Typechecking) [Stmt Typechecking] -> String -> IO ()
 x `shouldPreprocessAs` prog = do
-    stmts <- evalEnv newEnv x
+    stmts <- evalEnv (newEnv Preprocessor) x
     progStmts <- evalStr prog
     stmts `shouldBe` progStmts
 
@@ -170,9 +170,9 @@ parserTests = do
 compilerTests = do
     describe "receiveValue" $ do
         it "subtracts from uint types flowed into consume " $ do
-            stmts <- evalEnv newEnv (receiveValue Nat (SolVar "x") (SolVar "x") Consume)
+            stmts <- evalEnv (newEnv Compiler) (receiveValue Nat (SolVar "x") (SolVar "x") Consume)
             stmts `shouldBe` [SolAssign (SolVar "x") (SolSub (SolVar "x") (SolVar "x"))]
 
         it "deletes non-uint types flowed into consume" $ do
-            stmts <- evalEnv newEnv (receiveValue PsaBool (SolVar "x") (SolVar "x") Consume)
+            stmts <- evalEnv (newEnv Compiler) (receiveValue PsaBool (SolVar "x") (SolVar "x") Consume)
             stmts `shouldBe` [Delete (SolVar "x")]

--- a/Compiler/test/Spec.hs
+++ b/Compiler/test/Spec.hs
@@ -95,8 +95,7 @@ preprocessorTests = do
         it "pushes negations down to the atomic conditions" $ do
             cond <- parseAndCheck parsePrecondition "(0 = 1) and (x = y or 0 < 10)"
             expected <- parseAndCheck parsePrecondition "(0 != 1) or (x != y and 0 >= 10)"
-            res <- evalEnv newEnv (expandNegate cond)
-            res `shouldBe` expected
+            expandNegate cond `shouldBe` expected
 
     describe "preprocess" $ do
         it "infers ommitted any type quantities" $ do


### PR DESCRIPTION
Allow for the Preprocessor to infer omitted type quantities (fungible types are inferred as `any`, and non-fungible types as `one`). To support this, introduced a multi-stage AST based on [Trees that Grow](https://www.microsoft.com/en-us/research/uploads/prod/2016/11/trees-that-grow.pdf):

- Introduced three new "Phase" types, `Preprocessing`, `Typechecking`, and `Compiling`.
- Parameterized existing AST types on phase and introduced a type synonym family `XType` which is either `InferrableType` or `QuantifiedType` depending on phase.
- Added a new file `Transform.hs` with functions for converting datatypes between phases.
- Separated errors based on phase. Added an `ErrorCat` datatype and the `Errorable` typeclass to facilitate this.
- Added new typeclasses `ProgramTransform` (for converting AST types from one phase to another) and `PhaseTransition` (for transitioning between `Envs` from one phase to another).
- Miscellaneous other changes to handle polymorphic functions which operate across phases.

Closes #4.