### PR TITLE
Add simple inference for records, multisets

### DIFF
--- a/Compiler/src/AST.hs
+++ b/Compiler/src/AST.hs
@@ -24,23 +24,30 @@ class DefinesXType p where
     type XType p    :: *
     extractBaseType :: XType p -> BaseType p
     replaceBaseType :: XType p -> BaseType p -> XType p
+    bot :: XType p
 
 instance DefinesXType Preprocessing where
     type XType Preprocessing = InferrableType Preprocessing
+
     extractBaseType (Complete (q, t)) = t
     extractBaseType (Infer t) = t
+
     replaceBaseType (Complete (q, _)) t = Complete (q, t)
     replaceBaseType (Infer _) t = Infer t
+
+    bot = Complete (Any, Bot)
 
 instance DefinesXType Typechecking where
     type XType Typechecking = QuantifiedType Typechecking
     extractBaseType (q, t) = t
     replaceBaseType (q, _) t = (q, t)
+    bot = (Any, Bot)
 
 instance DefinesXType Compiling where
     type XType Compiling = QuantifiedType Compiling
     extractBaseType (q, t) = t
     replaceBaseType (q, _) t = (q, t)
+    bot = (Any, Bot)
 
 -- AST types, parameterized by compiler phase
 data BaseType phase = Nat | PsaBool | PsaString | Address
@@ -53,6 +60,7 @@ type QuantifiedType phase = (TyQuant, BaseType phase)
 
 data InferrableType phase = Complete (QuantifiedType phase)
                           | Infer (BaseType phase)
+                          | InferredType
 
 data VarDef phase = VarDef String (XType phase)
 
@@ -241,6 +249,7 @@ instance PrettyPrint (XType phase) => PrettyPrint (QuantifiedType phase) where
 instance PrettyPrint (XType phase) => PrettyPrint (InferrableType phase) where
     prettyPrint (Complete qt) = prettyPrint qt
     prettyPrint (Infer baseT) = ["infer " ++ prettyStr baseT]
+    prettyPrint InferredType = ["inferred"]
 
 instance PrettyPrint (XType phase) => PrettyPrint (VarDef phase) where
     prettyPrint (VarDef x t) = [ x ++ " : " ++ prettyStr t ]

--- a/Compiler/src/Parser.hs
+++ b/Compiler/src/Parser.hs
@@ -278,7 +278,8 @@ parseRecordLit = do
 
 parseRecordMember :: Parser (VarDef Preprocessing, Locator Preprocessing)
 parseRecordMember = do
-    vdef <- parseVarDef
+    vdef <- try parseVarDef <|>
+            (VarDef <$> parseVarName <*> pure InferredType)
     symbol $ string "|->"
     (vdef,) <$> parseLocator
 
@@ -288,8 +289,7 @@ parseLocators = parseDelimList "," parseLocator
 parseMultiset :: Parser (Locator Preprocessing)
 parseMultiset = do
     symbol $ string "["
-    t <- symbol parseType
-    symbol $ string ";"
+    t <- option InferredType $ try $ symbol parseType <* symbol (string ";")
     elems <- parseLocators
     symbol $ string "]"
     pure $ Multiset t elems

--- a/Compiler/src/Transform.hs
+++ b/Compiler/src/Transform.hs
@@ -79,7 +79,7 @@ transformPrecondition (BinOp op a b) = BinOp op <$> transformLocator a <*> trans
 
 transformPrecondition (NegateCond cond) = NegateCond <$> transformPrecondition cond
 
-transformStmt :: (Phase a, Phase b, Phase c, ProgramTransform a b, PhaseTransition a c) => Stmt a -> State (Env c) (Stmt b)
+transformStmt :: forall a b c. (Phase a, Phase b, Phase c, ProgramTransform a b, PhaseTransition a c) => Stmt a -> State (Env c) (Stmt b)
 transformStmt (Flow src dst) = Flow <$> transformLocator src <*> transformLocator dst
 
 transformStmt (FlowTransform src transformer dst) = FlowTransform <$> transformLocator src <*> transformTransformer transformer <*> transformLocator dst

--- a/Compiler/stack.yaml
+++ b/Compiler/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.26
+resolver: lts-17.5
 
 packages:
 - .

--- a/Compiler/stack.yaml.lock
+++ b/Compiler/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/26.yaml
-    sha256: cdbc5db9c1afe80a5998247939027a0c7db92fa0f20b5cd01596ec3da628b622
-  original: lts-16.26
+    size: 565266
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/5.yaml
+    sha256: 78e8ebabf11406261abbc95b44f240acf71802630b368888f6d758de7fc3a2f7
+  original: lts-17.5

--- a/Compiler/test/resources/infer-record.flow
+++ b/Compiler/test/resources/infer-record.flow
@@ -1,0 +1,10 @@
+var r : { x : nat, y : bool } <-- {
+    x |-> 0x123,
+    y |-> false
+}
+only when r.x = 12
+
+[ 0,1,10 ] --> var xs : list nat
+xs --> var tot : nat
+only when tot = 12
+


### PR DESCRIPTION
This PR, along with the recent work for type quantity inference, makes writing record and multiset literals considerably nicer. For example, we can now write:
```
type Token is unique immutable asset nat
0 --> new Token() --> var tok : Token
var newAccount : { owner : address, balance : list Token } <-- {
    owner |-> 0x123,
    balance |-> [ tok ]
}
```
instead of
```
// ...
var newAccount : { owner : one address, balance : one list one Token } <-- {
    owner : one address |-> 0x123,
    balance : any list one Token |-> [ one Token ; tok ]
}
```
